### PR TITLE
chore: Update README and add coverage report

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
-	echo "Provide a single argument with a version of the release draft to use." >&2
-	echo "Usage: $0 <VERSION>"
-	exit 1
+  echo "Provide a single argument with a version of the release draft to use." >&2
+  echo "Usage: $0 <VERSION>"
+  exit 1
 fi
 
 VERSION="$1"
@@ -15,62 +15,62 @@ RELEASE_NOTES=$(gh release view "$VERSION" --json body --jq .body)
 BREAKING_CHANGES_HEADER="Breaking Changes"
 RELEASE_NOTES_HEADER="Release Notes"
 
-commit_message_re="-\s(.*)\s(\(#[0-9]+\)\s@.*)"
+commit_message_re="-\s.*\s\(#([0-9]+)\)\s@.*"
 rls_header_re="^##.*(Features|$BREAKING_CHANGES_HEADER|Bug Fixes|Fixed Vulnerabilities)"
 
 extract_header() {
-	local commit="$1"
-	local header_name="$2"
-	awk "
+  local body="$1"
+  local header_name="$2"
+  awk "
     /^\s?$/ {next};
     /^--+/ {rn=0};
     /^Signed-off-by|Co-authored-by/ {rn=0};
     /^## $header_name/ {rn=1};
     rn && !/^##/ && !/^--+/ {print};
-    /^##/ && !/^## $header_name/ {rn=0}" <<<"$commit"
+    /^##/ && !/^## $header_name/ {rn=0}" <<<"$body"
 }
 
 indent() {
-	while IFS= read -r line; do
-		printf "  %s\n" "${line%"${line##*[![:space:]]}"}"
-	done <<<"$1"
+  while IFS= read -r line; do
+    printf "  %s\n" "${line%"${line##*[![:space:]]}"}"
+  done <<<"$1"
 }
 
 new_notes=""
 rls_header=""
 while IFS= read -r line; do
-	new_notes+="$line\n"
-	if [[ $line == \##* ]]; then
-		if ! [[ $line =~ $rls_header_re ]]; then
-			rls_header=""
-			continue
-		fi
-		rls_header="${BASH_REMATCH[1]}"
-	fi
-	if [[ $rls_header == "" ]] || [[ $line != -* ]] || [[ $line == *"@renovate"* ]]; then
-		continue
-	fi
-	if ! [[ $line =~ $commit_message_re ]]; then
-		continue
-	fi
-	commit_msg="${BASH_REMATCH[1]}"
-	commit_body=$(git log -F --grep "$commit_msg" -n1 --pretty="%b")
+  new_notes+="$line\n"
+  if [[ $line == \##* ]]; then
+    if ! [[ $line =~ $rls_header_re ]]; then
+      rls_header=""
+      continue
+    fi
+    rls_header="${BASH_REMATCH[1]}"
+  fi
+  if [[ $rls_header == "" ]] || [[ $line != -* ]] || [[ $line == *"@renovate"* ]]; then
+    continue
+  fi
+  if ! [[ $line =~ $commit_message_re ]]; then
+    continue
+  fi
+  pr_number="${BASH_REMATCH[1]}"
+  pr_body=$(gh pr view "$pr_number" --json body --jq '.body')
 
-	add_notes() {
-		local notes="$1"
-		if [[ $notes != "" ]]; then
-			new_notes+=$(indent "> $notes")
-			new_notes+="\n"
-		fi
-	}
+  add_notes() {
+    local notes="$1"
+    if [[ $notes != "" ]]; then
+      new_notes+=$(indent "> $notes")
+      new_notes+="\n"
+    fi
+  }
 
-	rn=$(extract_header "$commit_body" "$RELEASE_NOTES_HEADER")
-	bc=$(extract_header "$commit_body" "$BREAKING_CHANGES_HEADER")
+  rn=$(extract_header "$pr_body" "$RELEASE_NOTES_HEADER")
+  bc=$(extract_header "$pr_body" "$BREAKING_CHANGES_HEADER")
 
-	case $rls_header in
-	"$BREAKING_CHANGES_HEADER") add_notes "$bc" ;;
-	*) add_notes "$rn" ;;
-	esac
+  case $rls_header in
+  "$BREAKING_CHANGES_HEADER") add_notes "$bc" ;;
+  *) add_notes "$rn" ;;
+  esac
 
 done <<<"$RELEASE_NOTES"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,3 +19,13 @@ jobs:
           enable-cache: true
       - name: Run unit tests
         run: devbox run -- make test
+      - name: Update coverage report
+        uses: ncruces/go-coverage-report@v0
+        with:
+          report: true
+          chart: true
+          amend: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GO_COVERAGE_TOKEN }}
+        if: github.event_name == 'push'
+        continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # govy
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/nobl9/govy.svg)](https://pkg.go.dev/github.com/nobl9/govy)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nobl9/govy)](https://goreportcard.com/report/github.com/nobl9/govy)
+[![Go Coverage](https://github.com/nobl9/govy/wiki/coverage.svg)](https://raw.githack.com/wiki/nobl9/govy/coverage.html)
+
 Validation library for Go that uses a functional interface for building
 strongly-typed validation rules, powered by generics and
 [reflection free](#reflection).

--- a/pkg/govyconfig/config.go
+++ b/pkg/govyconfig/config.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	inferredNames                  = make(map[string]InferredName)
-	nameInferFunc    NameInferFunc = NameInferDefaultRule
+	nameInferFunc    NameInferFunc = NameInferDefaultFunc
 	nameInferMode                  = NameInferModeDisable
 	includeTestFiles               = false
 
@@ -101,8 +101,8 @@ func GetNameInferMode() NameInferMode {
 	return nameInferMode
 }
 
-// SetNameInferFunc sets the rule for inferring field names from struct tags.
-// It overrides the default rule [NameInferDefaultRule].
+// SetNameInferFunc sets the function for inferring field names from struct tags.
+// It overrides the default function [NameInferDefaultFunc].
 // It's safe to call this function concurrently.
 func SetNameInferFunc(rule NameInferFunc) {
 	mu.Lock()
@@ -121,9 +121,9 @@ func GetNameInferFunc() NameInferFunc {
 // Tag value is the raw value of the struct tag, it needs to be parsed with [reflect.StructTag].
 type NameInferFunc func(fieldName, tagValue string) string
 
-// NameInferDefaultRule is the default rule for inferring field names from struct tags,
-// it looks for json and yaml tags, preferring json if both are set.
-func NameInferDefaultRule(fieldName, tagValue string) string {
+// NameInferDefaultFunc is the default function for inferring field names from struct tags.
+// It looks for json and yaml tags, preferring json if both are set.
+func NameInferDefaultFunc(fieldName, tagValue string) string {
 	for _, tagKey := range []string{"json", "yaml"} {
 		tagValues := strings.Split(
 			reflect.StructTag(strings.Trim(tagValue, "`")).Get(tagKey),

--- a/pkg/govyconfig/example_test.go
+++ b/pkg/govyconfig/example_test.go
@@ -139,15 +139,15 @@ func ExampleSetNameInferMode_invalidUsage() {
 	//   - should be equal to 'Jerry'
 }
 
-// By default govy's name inferrence is first checking for either json or yaml tags.
+// By default govy's name inference is first checking for either json or yaml tags.
 // If either is set it will use the value of the tag as the property name, see [govyconfig.NameInferDefaultFunc].
 //
-// This behaviour can be customized by providing a custom [govyconfig.NameInferFunc]
+// This behavior can be customized by providing a custom [govyconfig.NameInferFunc]
 // via [govyconfig.SetNameInferFunc].
 // Note that the tag value is the raw value of the struct tag,
 // it needs to be further parsed with [reflect.StructTag].
 //
-// In the example below we're setting a custom name inferrence function which always returns the exact field name.
+// In the example below we're setting a custom name inference function which always returns the exact field name.
 func ExampleSetNameInferFunc() {
 	govyconfig.SetNameInferFunc(func(fieldName, tagValue string) string { return fieldName })
 	govyconfig.SetNameInferMode(govyconfig.NameInferModeRuntime)


### PR DESCRIPTION
## Summary

Added badges providing easy access to docs and [goreportcard](https://goreportcard.com/report/github.com/nobl9/govy).
Added experimental Go coverage report generation (we might switch to Codecov if the license permits it).
Corrected naming of the `NameInferDefaultRule`.

## Breaking Changes

Changed `NameInferDefaultRule` to `NameInferDefaultFunc`.
The change can be easily applied with the following command: `gofmt -r 'govyconfig.NameInferDefaultRule -> govyconfig.NameInferDefaultFunc'`.
