### PR TITLE
feat: Add WithNameFunc to Validator

### DIFF
--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -72,6 +72,25 @@ func ExampleValidator_WithName() {
 	//   - always fails
 }
 
+// If statically defined name through [govy.Validator.WithName] is not enough,
+// you can use [govy.Validator.WithNameFunc].
+// The functions receives the entity's instance you're validating and returns a string name.
+func ExampleValidator_WithNameFunc() {
+	v := govy.New(
+		govy.For(func(t Teacher) string { return t.Name }).
+			Rules(govy.NewRule(func(name string) error { return fmt.Errorf("always fails") })),
+	).WithNameFunc(func(t Teacher) string { return "Teacher " + t.Name })
+
+	err := v.Validate(Teacher{Name: "John"})
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// Validation for Teacher John has failed for the following properties:
+	//   - always fails
+}
+
 // You can also add [govy.Validator] name during runtime,
 // by calling [govy.ValidatorError.WithName] function on the returned error.
 //

--- a/pkg/govy/validator_test.go
+++ b/pkg/govy/validator_test.go
@@ -97,6 +97,20 @@ func TestValidatorWithName(t *testing.T) {
     - test`)
 }
 
+func TestValidatorWithNameFunc(t *testing.T) {
+	r := govy.New(
+		govy.For(func(m mockValidatorStruct) string { return "test" }).
+			WithName("test").
+			Rules(govy.NewRule(func(v string) error { return errors.New("test") })),
+	).WithNameFunc(func(m mockValidatorStruct) string { return "validator with field: " + m.Field })
+
+	err := r.Validate(mockValidatorStruct{Field: "FIELD"})
+	assert.Require(t, assert.Error(t, err))
+	assert.EqualError(t, err, `Validation for validator with field: FIELD has failed for the following properties:
+  - 'test' with value 'test':
+    - test`)
+}
+
 func TestValidatorInferName(t *testing.T) {
 	r := govy.New(
 		govy.For(func(m mockValidatorStruct) string { return "test" }).


### PR DESCRIPTION
## Motivation

It's often the case that we wan't to dynamically construct the validated entity's name.
It would be useful to provide a function that can do that for us.

## Release Notes

Added `Validator.WithNameFunc` function which can be used to dynamically set the validator's name per-instance.