### PR TITLE
chore: Simplify StringDNSLabel rule

### DIFF
--- a/docs/validator-comparison/example_test.go
+++ b/docs/validator-comparison/example_test.go
@@ -226,9 +226,9 @@ func Example_govy() {
 	//   - 'kind' with value 'Project':
 	//     - should be equal to 'Service'
 	//   - 'metadata.name' with value 'slo-status api':
-	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 	//   - 'metadata.project' with value 'default project':
-	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 	//   - 'metadata.labels.ke y' with key 'ke y':
 	//     - string must match regular expression: '^\p{Ll}([_\-0-9\p{Ll}]*[0-9\p{Ll}])?$'
 }

--- a/pkg/govy/test_data/expected_pod_plan.json
+++ b/pkg/govy/test_data/expected_pod_plan.json
@@ -68,13 +68,9 @@
       "type": "string",
       "rules": [
         {
-          "description": "length must be between 1 and 63",
-          "errorCode": "string_length"
-        },
-        {
-          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc')",
+          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-name', '123-abc')",
           "details": "an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character",
-          "errorCode": "string_match_regexp"
+          "errorCode": "string_dns_label"
         }
       ]
     },
@@ -143,13 +139,9 @@
       "type": "string",
       "rules": [
         {
-          "description": "length must be between 1 and 63",
-          "errorCode": "string_length"
-        },
-        {
-          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc')",
+          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-name', '123-abc')",
           "details": "an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character",
-          "errorCode": "string_match_regexp"
+          "errorCode": "string_dns_label"
         }
       ]
     },

--- a/pkg/rules/regex.go
+++ b/pkg/rules/regex.go
@@ -12,7 +12,7 @@ var (
 	uuidRegexp  = lazyRegexCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 	asciiRegexp = lazyRegexCompile(`^[\x00-\x7F]*$`)
 	// Ref: https://www.ietf.org/rfc/rfc1123.txt
-	rfc1123DnsLabelRegexp = lazyRegexCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+	rfc1123DnsLabelRegexp = lazyRegexCompile("^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$")
 )
 
 // lazyRegexCompile returns a function that compiles the regular expression

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -63,13 +63,11 @@ func StringDenyRegexp(re *regexp.Regexp, examples ...string) govy.Rule[string] {
 }
 
 // StringDNSLabel ensures the property's value is a valid DNS label as defined by RFC 1123.
-func StringDNSLabel() govy.RuleSet[string] {
-	return govy.NewRuleSet(
-		StringLength(1, 63),
-		StringMatchRegexp(rfc1123DnsLabelRegexp(), "my-name", "123-abc").
-			WithDetails("an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-',"+
-				" and must start and end with an alphanumeric character"),
-	).WithErrorCode(ErrorCodeStringDNSLabel)
+func StringDNSLabel() govy.Rule[string] {
+	return StringMatchRegexp(rfc1123DnsLabelRegexp(), "my-name", "123-abc").
+		WithDetails("an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-'," +
+			" and must start and end with an alphanumeric character").
+		WithErrorCode(ErrorCodeStringDNSLabel)
 }
 
 // StringEmail ensures the property's value is a valid email address.

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -82,9 +82,7 @@ func TestStringDNSLabel(t *testing.T) {
 		err := StringDNSLabel().Validate(tc.in)
 		if tc.shouldFail {
 			assert.Error(t, err)
-			for _, e := range err.(govy.RuleSetError) {
-				assert.True(t, govy.HasErrorCode(e, ErrorCodeStringDNSLabel))
-			}
+			assert.True(t, govy.HasErrorCode(err, ErrorCodeStringDNSLabel))
 		} else {
 			assert.NoError(t, err)
 		}


### PR DESCRIPTION
## Motivation

There's no need for `StringDNSLabel` to be a `RuleSet`, we can ensure the proper length with regular expression.

## Breaking Changes

`StringDNSLabel` is no longer a `RuleSet`, instead it's now a single `Rule`.