### PR TITLE
feat: Add StringGitRef rule

### DIFF
--- a/pkg/rules/error_codes.go
+++ b/pkg/rules/error_codes.go
@@ -38,6 +38,7 @@ const (
 	ErrorCodeStringMinLength      govy.ErrorCode = "string_min_length"
 	ErrorCodeStringMaxLength      govy.ErrorCode = "string_max_length"
 	ErrorCodeStringTitle          govy.ErrorCode = "string_title"
+	ErrorCodeStringGitRef         govy.ErrorCode = "string_git_ref"
 	ErrorCodeSliceLength          govy.ErrorCode = "slice_length"
 	ErrorCodeSliceMinLength       govy.ErrorCode = "slice_min_length"
 	ErrorCodeSliceMaxLength       govy.ErrorCode = "slice_max_length"


### PR DESCRIPTION
## Summary

Added `StringGitRef` validation rule which checks if a string is a valid git reference according to the rules defined here: https://git-scm.com/docs/git-check-ref-format.

## Release Notes

Added `StringGitRef` validation rule which checks if a string is a valid git reference according to the rules defined by [git-check-ref-format](https://git-scm.com/docs/git-check-ref-format).
