### PR TITLE
feat: Add StringRegexp rule

### DIFF
--- a/pkg/rules/error_codes.go
+++ b/pkg/rules/error_codes.go
@@ -43,6 +43,7 @@ const (
 	ErrorCodeStringMatchFileSystemPath govy.ErrorCode = "string_match_file_system_path"
 	ErrorCodeStringFilePath            govy.ErrorCode = "string_file_path"
 	ErrorCodeStringDirPath             govy.ErrorCode = "string_dir_path"
+	ErrorCodeStringRegexp              govy.ErrorCode = "string_regexp"
 	ErrorCodeSliceLength               govy.ErrorCode = "slice_length"
 	ErrorCodeSliceMinLength            govy.ErrorCode = "slice_min_length"
 	ErrorCodeSliceMaxLength            govy.ErrorCode = "slice_max_length"

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -470,6 +470,25 @@ func StringMatchFileSystemPath(pattern string) govy.Rule[string] {
 		WithDescription(msg)
 }
 
+// StringRegexp ensures the property's value is a valid regular expression.
+// The accepted regular expression syntax must comply to RE2.
+// It is described at https://golang.org/s/re2syntax, except for \C.
+// For an overview of the syntax, see [regexp/syntax] package.
+//
+// [regexp/syntax]: https://pkg.go.dev/regexp/syntax
+func StringRegexp() govy.Rule[string] {
+	msg := "string must be a valid regular expression"
+	return govy.NewRule(func(s string) error {
+		if _, err := regexp.Compile(s); err != nil {
+			return fmt.Errorf("%s: %w", msg, err)
+		}
+		return nil
+	}).
+		WithErrorCode(ErrorCodeStringRegexp).
+		WithDetails(`the accepted regular expression syntax must comply to RE2, it is described at https://golang.org/s/re2syntax, except for \C; for an overview of the syntax, see https://pkg.go.dev/regexp/syntax`).
+		WithDescription(msg)
+}
+
 func prettyExamples(examples []string) string {
 	if len(examples) == 0 {
 		return ""

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -485,6 +485,7 @@ func StringRegexp() govy.Rule[string] {
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringRegexp).
+		// nolint: lll
 		WithDetails(`the accepted regular expression syntax must comply to RE2, it is described at https://golang.org/s/re2syntax, except for \C; for an overview of the syntax, see https://pkg.go.dev/regexp/syntax`).
 		WithDescription(msg)
 }

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -486,7 +486,7 @@ func StringRegexp() govy.Rule[string] {
 	}).
 		WithErrorCode(ErrorCodeStringRegexp).
 		// nolint: lll
-		WithDetails(`the accepted regular expression syntax must comply to RE2, it is described at https://golang.org/s/re2syntax, except for \C; for an overview of the syntax, see https://pkg.go.dev/regexp/syntax`).
+		WithDetails(`the regular expression syntax must comply to RE2, it is described at https://golang.org/s/re2syntax, except for \C; for an overview of the syntax, see https://pkg.go.dev/regexp/syntax`).
 		WithDescription(msg)
 }
 

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -1228,3 +1228,61 @@ func BenchmarkStringMatchFileSystemPath(b *testing.B) {
 		}
 	}
 }
+
+// test cases copied from Go's [regexp] standard library.
+var stringRegexpTestCases = []*struct {
+	in         string
+	shouldFail bool
+}{
+	// cspell:disable
+	{``, false},
+	{`.`, false},
+	{`^.$`, false},
+	{`a`, false},
+	{`a*`, false},
+	{`a+`, false},
+	{`a?`, false},
+	{`a|b`, false},
+	{`a*|b*`, false},
+	{`(a*|b)(c*|d)`, false},
+	{`[a-z]`, false},
+	{`[a-abc-c\-\]\[]`, false},
+	{`[a-z]+`, false},
+	{`[abc]`, false},
+	{`[^1234]`, false},
+	{`[^\n]`, false},
+	{`\!\\`, false},
+	{`*`, true},
+	{`+`, true},
+	{`?`, true},
+	{`(abc`, true},
+	{`abc)`, true},
+	{`x[a-z`, true},
+	{`[z-a]`, true},
+	{`abc\`, true},
+	{`a**`, true},
+	{`a*+`, true},
+	{`\x`, true},
+	{strings.Repeat(`\pL`, 27000), true},
+	// cspell:enable
+}
+
+func TestStringRegexp(t *testing.T) {
+	for _, tc := range stringRegexpTestCases {
+		err := StringRegexp().Validate(tc.in)
+		if tc.shouldFail {
+			assert.ErrorContains(t, err, "string must be a valid regular expression")
+			assert.True(t, govy.HasErrorCode(err, ErrorCodeStringRegexp))
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func BenchmarkStringRegexp(b *testing.B) {
+	for range b.N {
+		for _, tc := range stringRegexpTestCases {
+			_ = StringRegexp().Validate(tc.in)
+		}
+	}
+}


### PR DESCRIPTION
## Release Notes

Added `StringRegexp` validation rule which verifies if a string is a valid regular expression according to https://pkg.go.dev/regexp/syntax rules.
