### PR TITLE
feat: Add StringCrontab rule

### DIFF
--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -308,18 +308,19 @@ func ExampleForPointer() {
 	//     - length must be less than or equal to 5
 }
 
-// [Transform] constructor can be used to transform the property value before it's passed to the rules' evaluation.
+// [govy.Transform] constructor can be used to transform the property's value
+// before it's passed to the rules' evaluation.
 // It's useful when you want to use rules that operate on a different type than the property's.
 //
-// Along with the standard [PropertyGetter] it accepts a [Transformer] function which takes the property value
-// and returns the transformed value along with an error.
-// If the error is not nil, the validation will fail with the error message returned by [Transformer] error.
+// Along with the standard [govy.PropertyGetter] it accepts a [govy.Transformer] function
+// which takes the property value and returns the transformed value along with an error.
+// If the error is not nil, the validation will fail with the error message returned by [govy.Transformer] error.
 //
 // In this example we'll use [time.ParseDuration] to transform the string value of [Clock.Duration] to [time.Duration].
-// The first value we'll validate will force [Transformer] to return an error, the second will succeed transformation,
-// but it will fail the validation for [rules.DurationPrecision].
+// The first value we'll validate will force [govy.Transformer] to return an error,
+// the second will succeed transformation, but it will fail the validation for [rules.DurationPrecision].
 //
-// Notice how the [Transformer] shape adheres to a lot of standard library conversion/parsing functions.
+// Notice how the [govy.Transformer] shape adheres to a lot of standard library conversion/parsing functions.
 func ExampleTransform() {
 	type Clock struct {
 		Duration string `json:"duration"`

--- a/pkg/rules/crontab.go
+++ b/pkg/rules/crontab.go
@@ -1,0 +1,157 @@
+package rules
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+var errInvalidCrontab = errors.New("invalid crontab expression")
+
+var crontabMonthsMap = map[string]int{
+	"JAN": 1, "FEB": 2, "MAR": 3, "APR": 4,
+	"MAY": 5, "JUN": 6, "JUL": 7, "AUG": 8,
+	"SEP": 9, "OCT": 10, "NOV": 11, "DEC": 12,
+}
+
+var crontabDaysMap = map[string]int{
+	"SUN": 0, "MON": 1, "TUE": 2, "WED": 3,
+	"THU": 4, "FRI": 5, "SAT": 6,
+}
+
+func parseCrontab(c string) error {
+	if strings.HasPrefix(c, "@") {
+		switch c {
+		case "@reboot", "@yearly", "@annually", "@monthly", "@weekly", "@daily", "@hourly":
+			return nil
+		default:
+			return errInvalidCrontab
+		}
+	}
+	fields := strings.Fields(c)
+	if len(fields) != 5 {
+		return errors.New("crontab expression must have exactly 5 fields")
+	}
+	for i, field := range fields {
+		if field == "*" {
+			continue
+		}
+		if strings.HasPrefix(field, "*/") {
+			if len(field) < 3 {
+				return errInvalidCrontab
+			}
+			if _, err := strconv.Atoi(field[2:]); err != nil {
+				return errInvalidCrontab
+			}
+			continue
+		}
+		switch i {
+		case 0:
+			if !validateCrontabField(field, 0, 59, crontabParseStandardField) {
+				return errInvalidCrontab
+			}
+		case 1:
+			if !validateCrontabField(field, 0, 23, crontabParseStandardField) {
+				return errInvalidCrontab
+			}
+		case 2:
+			if !validateCrontabField(field, 1, 31, crontabParseStandardField) {
+				return errInvalidCrontab
+			}
+		case 3:
+			if !validateCrontabField(field, 1, 12, crontabParseMonthField) {
+				return errInvalidCrontab
+			}
+		case 4:
+			if !validateCrontabField(field, 0, 7, crontabParseDayField) {
+				return errInvalidCrontab
+			}
+		}
+	}
+	return nil
+}
+
+type crontabFieldParseFunc func(string) (int, bool)
+
+func crontabParseStandardField(v string) (int, bool) {
+	if v == "" {
+		return -1, false
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return -1, false
+	}
+	return i, true
+}
+
+func crontabParseMonthField(v string) (int, bool) {
+	if v == "" {
+		return -1, false
+	}
+	if i, ok := crontabMonthsMap[strings.ToUpper(v)]; ok {
+		return i, true
+	}
+	return crontabParseStandardField(v)
+}
+
+func crontabParseDayField(v string) (int, bool) {
+	if v == "" {
+		return -1, false
+	}
+	if i, ok := crontabDaysMap[strings.ToUpper(v)]; ok {
+		return i, true
+	}
+	return crontabParseStandardField(v)
+}
+
+func validateCrontabField(field string, lowerLimit, upperLimit int, parse crontabFieldParseFunc) bool {
+	for _, el := range strings.Split(field, ",") {
+		rangeIdx := strings.Index(el, "-")
+		if rangeIdx != -1 {
+			if rangeIdx == 0 || rangeIdx == len(el)-1 {
+				return false
+			}
+			// Check lower range bound.
+			l, ok := parse(el[:rangeIdx])
+			if !ok {
+				return false
+			}
+			if l < lowerLimit || l > upperLimit {
+				return false
+			}
+			// Take step value into account.
+			stepIdx := strings.Index(el, "/")
+			if stepIdx == -1 {
+				stepIdx = len(el)
+			} else if stepIdx == len(el)-1 {
+				return false
+			} else {
+				if v, err := strconv.Atoi(el[stepIdx+1:]); err != nil || v < 0 {
+					return false
+				}
+			}
+			// Check upper range bound.
+			u, ok := parse(el[rangeIdx+1 : stepIdx])
+			if !ok {
+				return false
+			}
+			if u < lowerLimit || u > upperLimit {
+				return false
+			}
+			// Compare lower and upper bounds.
+			if l > u {
+				return false
+			}
+			break
+		} else {
+			v, ok := parse(el)
+			if !ok {
+				return false
+			}
+			if v < lowerLimit || v > upperLimit {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/rules/crontab.go
+++ b/pkg/rules/crontab.go
@@ -121,11 +121,12 @@ func validateCrontabField(field string, lowerLimit, upperLimit int, parse cronta
 			}
 			// Take step value into account.
 			stepIdx := strings.Index(el, "/")
-			if stepIdx == -1 {
+			switch {
+			case stepIdx == -1:
 				stepIdx = len(el)
-			} else if stepIdx == len(el)-1 {
+			case stepIdx == len(el)-1:
 				return false
-			} else {
+			default:
 				if v, err := strconv.Atoi(el[stepIdx+1:]); err != nil || v < 0 {
 					return false
 				}

--- a/pkg/rules/error_codes.go
+++ b/pkg/rules/error_codes.go
@@ -44,7 +44,7 @@ const (
 	ErrorCodeStringFilePath            govy.ErrorCode = "string_file_path"
 	ErrorCodeStringDirPath             govy.ErrorCode = "string_dir_path"
 	ErrorCodeStringRegexp              govy.ErrorCode = "string_regexp"
-	ErrorCodeStringCron                govy.ErrorCode = "string_cron"
+	ErrorCodeStringCrontab             govy.ErrorCode = "string_crontab"
 	ErrorCodeSliceLength               govy.ErrorCode = "slice_length"
 	ErrorCodeSliceMinLength            govy.ErrorCode = "slice_min_length"
 	ErrorCodeSliceMaxLength            govy.ErrorCode = "slice_max_length"

--- a/pkg/rules/error_codes.go
+++ b/pkg/rules/error_codes.go
@@ -44,6 +44,7 @@ const (
 	ErrorCodeStringFilePath            govy.ErrorCode = "string_file_path"
 	ErrorCodeStringDirPath             govy.ErrorCode = "string_dir_path"
 	ErrorCodeStringRegexp              govy.ErrorCode = "string_regexp"
+	ErrorCodeStringCron                govy.ErrorCode = "string_cron"
 	ErrorCodeSliceLength               govy.ErrorCode = "slice_length"
 	ErrorCodeSliceMinLength            govy.ErrorCode = "slice_min_length"
 	ErrorCodeSliceMaxLength            govy.ErrorCode = "slice_max_length"

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -497,9 +497,7 @@ func StringRegexp() govy.Rule[string] {
 // [crontab.guru]: https://crontab.guru
 func StringCrontab() govy.Rule[string] {
 	msg := "string must be a valid cron schedule expression"
-	return govy.NewRule(func(s string) error {
-		return parseCrontab(s)
-	}).
+	return govy.NewRule(parseCrontab).
 		WithMessage(msg).
 		WithErrorCode(ErrorCodeStringCron)
 }

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -490,6 +490,20 @@ func StringRegexp() govy.Rule[string] {
 		WithDescription(msg)
 }
 
+// StringCrontab ensures the property's value is a valid crontab schedule expression.
+// For more details on cron expressions read [crontab manual] and visit [crontab.guru].
+//
+// [crontab manual]: https://www.man7.org/linux/man-pages/man5/crontab.5.html
+// [crontab.guru]: https://crontab.guru
+func StringCrontab() govy.Rule[string] {
+	msg := "string must be a valid cron schedule expression"
+	return govy.NewRule(func(s string) error {
+		return parseCrontab(s)
+	}).
+		WithMessage(msg).
+		WithErrorCode(ErrorCodeStringCron)
+}
+
 func prettyExamples(examples []string) string {
 	if len(examples) == 0 {
 		return ""

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -499,7 +499,7 @@ func StringCrontab() govy.Rule[string] {
 	msg := "string must be a valid cron schedule expression"
 	return govy.NewRule(parseCrontab).
 		WithMessage(msg).
-		WithErrorCode(ErrorCodeStringCron)
+		WithErrorCode(ErrorCodeStringCrontab)
 }
 
 func prettyExamples(examples []string) string {

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -1406,7 +1406,7 @@ func getStringCronTestCases() []*stringCronTestCase {
 	return testCases
 }
 
-func TestStringCron(t *testing.T) {
+func TestStringCrontab(t *testing.T) {
 	for _, tc := range getStringCronTestCases() {
 		t.Run(tc.in, func(t *testing.T) {
 			err := StringCrontab().Validate(tc.in)
@@ -1420,7 +1420,7 @@ func TestStringCron(t *testing.T) {
 	}
 }
 
-func BenchmarkStringCron(b *testing.B) {
+func BenchmarkStringCrontab(b *testing.B) {
 	testCases := getStringCronTestCases()
 	for range b.N {
 		for _, tc := range testCases {

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -991,12 +993,12 @@ type stringFileSystemPathTestCase struct {
 	expectedErr error
 }
 
-func getStringFileSystemPathTestCases(root string) []stringFileSystemPathTestCase {
+func getStringFileSystemPathTestCases(root string) []*stringFileSystemPathTestCase {
 	addRoot := func(path string) string {
 		// We're not using filepath.Join because it cleans the path.
 		return root + string(filepath.Separator) + path
 	}
-	return []stringFileSystemPathTestCase{
+	return []*stringFileSystemPathTestCase{
 		{"~/dir1", nil},
 		{"~/dir1/", nil},
 		{addRoot("dir1"), nil},
@@ -1041,12 +1043,12 @@ func BenchmarkStringFileSystemPath(b *testing.B) {
 	}
 }
 
-func getStringFilePathTestCases(root string) []stringFileSystemPathTestCase {
+func getStringFilePathTestCases(root string) []*stringFileSystemPathTestCase {
 	addRoot := func(path string) string {
 		// We're not using filepath.Join because it cleans the path.
 		return root + string(filepath.Separator) + path
 	}
-	return []stringFileSystemPathTestCase{
+	return []*stringFileSystemPathTestCase{
 		{addRoot("dir1/file2"), nil},
 		{"~/dir1/file2", nil},
 		{addRoot("./file1"), nil},
@@ -1091,12 +1093,12 @@ func BenchmarkStringFilePath(b *testing.B) {
 	}
 }
 
-func getStringDirPathTestCases(root string) []stringFileSystemPathTestCase {
+func getStringDirPathTestCases(root string) []*stringFileSystemPathTestCase {
 	addRoot := func(path string) string {
 		// We're not using filepath.Join because it cleans the path.
 		return root + string(filepath.Separator) + path
 	}
-	return []stringFileSystemPathTestCase{
+	return []*stringFileSystemPathTestCase{
 		{addRoot("dir1"), nil},
 		{addRoot("dir1/file2/.."), nil},
 		{addRoot("."), nil},
@@ -1283,6 +1285,146 @@ func BenchmarkStringRegexp(b *testing.B) {
 	for range b.N {
 		for _, tc := range stringRegexpTestCases {
 			_ = StringRegexp().Validate(tc.in)
+		}
+	}
+}
+
+type stringCronTestCase struct {
+	in         string
+	shouldFail bool
+}
+
+func getStringCronTestCases() []*stringCronTestCase {
+	testCases := []*stringCronTestCase{
+		{"@annually", false},
+		{"@yearly", false},
+		{"@monthly", false},
+		{"@weekly", false},
+		{"@daily", false},
+		{"@hourly", false},
+		{"@reboot", false},
+		{"* * * * *", false},
+		{"* * * JAN,MAY,DEC *", false},
+		{"* * * JAN-DEC *", false},
+		{"* * * FEB-MAY/2 *", false},
+		{"* * * fEb-may/10 *", false},
+		{"* * * SEP-SEP/2 *", false},
+		{"* * * JAN-1 *", false},
+		{"* * * JAN-12 *", false},
+		{"* * * 1-DEC *", false},
+		{"* * * * FRI-7", false},
+		{"* * * * 2-WED", false},
+		{"* * * * THU-FRI", false},
+		{"* * * * TUE-THU/10", false},
+		{"* * * * SUN-MON", false},
+		{"* * * * WED-3", false},
+		{"* * * * THU,FRI,MON", false},
+		{"* * * * *", false},
+		{"", true},
+		{"  @hourly", true},
+		{"1h @every", true},
+		{"@every 1Y", true},
+		{"wrong", true},
+		{"@minutely", true},
+		{"@every 1h", true},
+		{"@every 1h30m10ts", true},
+		{"a * * * *", true},
+		{"1 b * * *", true},
+		{"1 1 c * *", true},
+		{"1 1 1 d *", true},
+		{"1 1 1 1 e", true},
+		{"* * * MAZ *", true},
+		{"* * * MAY-FEB/2 *", true},
+		{"* * * MAY-2 *", true},
+		{"* * * 2-JAN *", true},
+		{"* * * FEB-JUN/-10 *", true},
+		{"* * * JAN,MAY,DEZ *", true},
+		{"* * * * MOZ", true},
+		{"* * * * MON-SUN", true},
+		{"* * * * 7-FRI", true},
+		{"* * * * WED-2", true},
+		{"* * * * MON-FRI/-10", true},
+		{"* * * * THU,FRI,MOZ", true},
+	}
+	createCron := func(n int, format string, a ...any) string {
+		fields := strings.Fields("* * * * *")
+		fields[n] = fmt.Sprintf(format, a...)
+		return strings.Join(fields, " ")
+	}
+	for _, field := range []struct {
+		n, lower, upper int
+	}{
+		{0, 0, 59},
+		{1, 0, 23},
+		{2, 1, 31},
+		{3, 1, 12},
+		{4, 0, 7},
+	} {
+		getRandom := func() int {
+			return field.lower + rand.Intn(field.upper-field.lower)
+		}
+		testCases = append(testCases,
+			&stringCronTestCase{createCron(field.n, "%d", getRandom()), false},
+			&stringCronTestCase{createCron(field.n, "%d", field.lower), false},
+			&stringCronTestCase{createCron(field.n, "%d", field.upper), false},
+			&stringCronTestCase{createCron(field.n, "%d,%d", field.lower, field.upper), false},
+			&stringCronTestCase{createCron(field.n, "%d,%d", field.upper, field.lower), false},
+			&stringCronTestCase{createCron(field.n, "%d-%d", field.lower, field.upper), false},
+			&stringCronTestCase{createCron(field.n, "%d-%d/10", field.lower, field.upper), false},
+			&stringCronTestCase{createCron(field.n, "*/10"), false},
+			&stringCronTestCase{createCron(field.n, "%d", field.lower-1), true},
+			&stringCronTestCase{createCron(field.n, "%d", field.upper+1), true},
+			&stringCronTestCase{createCron(field.n, "%d,", field.lower), true},
+			&stringCronTestCase{createCron(field.n, "%d,%d", field.lower, field.upper+1), true},
+			&stringCronTestCase{createCron(field.n, "%d,%d", field.lower-1, field.upper), true},
+			&stringCronTestCase{createCron(field.n, "%d/10", getRandom()), true},
+			&stringCronTestCase{createCron(field.n, "%d,%d/10", field.lower, field.upper), true},
+			&stringCronTestCase{createCron(field.n, "a"), true},
+			&stringCronTestCase{createCron(field.n, "%d,a", field.lower), true},
+			&stringCronTestCase{createCron(field.n, "a,%d", field.upper), true},
+			&stringCronTestCase{createCron(field.n, "%d-", field.lower), true},
+			&stringCronTestCase{createCron(field.n, "%d-/", field.lower), true},
+			&stringCronTestCase{createCron(field.n, "-/"), true},
+			&stringCronTestCase{createCron(field.n, "%d-%d/", field.lower, field.upper), true},
+			&stringCronTestCase{createCron(field.n, "%d-%d/a", field.lower, field.upper), true},
+			&stringCronTestCase{createCron(field.n, "%d-%d/-10", field.lower, field.upper), true},
+			&stringCronTestCase{createCron(field.n, "%d-*/10", field.lower), true},
+			&stringCronTestCase{createCron(field.n, "*-*/10", field.lower, field.upper), true},
+			&stringCronTestCase{createCron(field.n, "*-%d/10", field.upper), true},
+		)
+	}
+	for month := range crontabMonthsMap {
+		testCases = append(testCases, &stringCronTestCase{createCron(3, month), false})
+	}
+	for day := range crontabDaysMap {
+		// Skip special cases for Sunday.
+		if strings.Contains(day, "-") {
+			continue
+		}
+		testCases = append(testCases, &stringCronTestCase{createCron(4, day), false})
+	}
+	return testCases
+}
+
+func TestStringCron(t *testing.T) {
+	for _, tc := range getStringCronTestCases() {
+		t.Run(tc.in, func(t *testing.T) {
+			err := StringCrontab().Validate(tc.in)
+			if tc.shouldFail {
+				assert.ErrorContains(t, err, "string must be a valid cron schedule expression")
+				assert.True(t, govy.HasErrorCode(err, ErrorCodeStringCron))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func BenchmarkStringCron(b *testing.B) {
+	testCases := getStringCronTestCases()
+	for range b.N {
+		for _, tc := range testCases {
+			_ = StringCrontab().Validate(tc.in)
 		}
 	}
 }

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -1289,13 +1289,13 @@ func BenchmarkStringRegexp(b *testing.B) {
 	}
 }
 
-type stringCronTestCase struct {
+type stringCrontabTestCase struct {
 	in         string
 	shouldFail bool
 }
 
-func getStringCronTestCases() []*stringCronTestCase {
-	testCases := []*stringCronTestCase{
+func getStringCronTestCases() []*stringCrontabTestCase {
+	testCases := []*stringCrontabTestCase{
 		{"@annually", false},
 		{"@yearly", false},
 		{"@monthly", false},
@@ -1364,44 +1364,44 @@ func getStringCronTestCases() []*stringCronTestCase {
 			return field.lower + rand.Intn(field.upper-field.lower)
 		}
 		testCases = append(testCases,
-			&stringCronTestCase{createCron(field.n, "%d", getRandom()), false},
-			&stringCronTestCase{createCron(field.n, "%d", field.lower), false},
-			&stringCronTestCase{createCron(field.n, "%d", field.upper), false},
-			&stringCronTestCase{createCron(field.n, "%d,%d", field.lower, field.upper), false},
-			&stringCronTestCase{createCron(field.n, "%d,%d", field.upper, field.lower), false},
-			&stringCronTestCase{createCron(field.n, "%d-%d", field.lower, field.upper), false},
-			&stringCronTestCase{createCron(field.n, "%d-%d/10", field.lower, field.upper), false},
-			&stringCronTestCase{createCron(field.n, "*/10"), false},
-			&stringCronTestCase{createCron(field.n, "%d", field.lower-1), true},
-			&stringCronTestCase{createCron(field.n, "%d", field.upper+1), true},
-			&stringCronTestCase{createCron(field.n, "%d,", field.lower), true},
-			&stringCronTestCase{createCron(field.n, "%d,%d", field.lower, field.upper+1), true},
-			&stringCronTestCase{createCron(field.n, "%d,%d", field.lower-1, field.upper), true},
-			&stringCronTestCase{createCron(field.n, "%d/10", getRandom()), true},
-			&stringCronTestCase{createCron(field.n, "%d,%d/10", field.lower, field.upper), true},
-			&stringCronTestCase{createCron(field.n, "a"), true},
-			&stringCronTestCase{createCron(field.n, "%d,a", field.lower), true},
-			&stringCronTestCase{createCron(field.n, "a,%d", field.upper), true},
-			&stringCronTestCase{createCron(field.n, "%d-", field.lower), true},
-			&stringCronTestCase{createCron(field.n, "%d-/", field.lower), true},
-			&stringCronTestCase{createCron(field.n, "-/"), true},
-			&stringCronTestCase{createCron(field.n, "%d-%d/", field.lower, field.upper), true},
-			&stringCronTestCase{createCron(field.n, "%d-%d/a", field.lower, field.upper), true},
-			&stringCronTestCase{createCron(field.n, "%d-%d/-10", field.lower, field.upper), true},
-			&stringCronTestCase{createCron(field.n, "%d-*/10", field.lower), true},
-			&stringCronTestCase{createCron(field.n, "*-*/10", field.lower, field.upper), true},
-			&stringCronTestCase{createCron(field.n, "*-%d/10", field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "%d", getRandom()), false},
+			&stringCrontabTestCase{createCron(field.n, "%d", field.lower), false},
+			&stringCrontabTestCase{createCron(field.n, "%d", field.upper), false},
+			&stringCrontabTestCase{createCron(field.n, "%d,%d", field.lower, field.upper), false},
+			&stringCrontabTestCase{createCron(field.n, "%d,%d", field.upper, field.lower), false},
+			&stringCrontabTestCase{createCron(field.n, "%d-%d", field.lower, field.upper), false},
+			&stringCrontabTestCase{createCron(field.n, "%d-%d/10", field.lower, field.upper), false},
+			&stringCrontabTestCase{createCron(field.n, "*/10"), false},
+			&stringCrontabTestCase{createCron(field.n, "%d", field.lower-1), true},
+			&stringCrontabTestCase{createCron(field.n, "%d", field.upper+1), true},
+			&stringCrontabTestCase{createCron(field.n, "%d,", field.lower), true},
+			&stringCrontabTestCase{createCron(field.n, "%d,%d", field.lower, field.upper+1), true},
+			&stringCrontabTestCase{createCron(field.n, "%d,%d", field.lower-1, field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "%d/10", getRandom()), true},
+			&stringCrontabTestCase{createCron(field.n, "%d,%d/10", field.lower, field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "a"), true},
+			&stringCrontabTestCase{createCron(field.n, "%d,a", field.lower), true},
+			&stringCrontabTestCase{createCron(field.n, "a,%d", field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "%d-", field.lower), true},
+			&stringCrontabTestCase{createCron(field.n, "%d-/", field.lower), true},
+			&stringCrontabTestCase{createCron(field.n, "-/"), true},
+			&stringCrontabTestCase{createCron(field.n, "%d-%d/", field.lower, field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "%d-%d/a", field.lower, field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "%d-%d/-10", field.lower, field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "%d-*/10", field.lower), true},
+			&stringCrontabTestCase{createCron(field.n, "*-*/10", field.lower, field.upper), true},
+			&stringCrontabTestCase{createCron(field.n, "*-%d/10", field.upper), true},
 		)
 	}
 	for month := range crontabMonthsMap {
-		testCases = append(testCases, &stringCronTestCase{createCron(3, month), false})
+		testCases = append(testCases, &stringCrontabTestCase{createCron(3, month), false})
 	}
 	for day := range crontabDaysMap {
 		// Skip special cases for Sunday.
 		if strings.Contains(day, "-") {
 			continue
 		}
-		testCases = append(testCases, &stringCronTestCase{createCron(4, day), false})
+		testCases = append(testCases, &stringCrontabTestCase{createCron(4, day), false})
 	}
 	return testCases
 }
@@ -1412,7 +1412,7 @@ func TestStringCrontab(t *testing.T) {
 			err := StringCrontab().Validate(tc.in)
 			if tc.shouldFail {
 				assert.ErrorContains(t, err, "string must be a valid cron schedule expression")
-				assert.True(t, govy.HasErrorCode(err, ErrorCodeStringCron))
+				assert.True(t, govy.HasErrorCode(err, ErrorCodeStringCrontab))
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
## Summary

- Added new validation rule for crontab expressions (standard syntax, not extended).
- Added missing example for `Transform`

## Release Notes

Added `StringCrontab` rule which verifies if a string is a valid crontab schedule expression according to the rules defined by [crontab](https://www.man7.org/linux/man-pages/man5/crontab.5.html).
