### PR TITLE
feat: Allow converting rules for pointers

### DIFF
--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -508,6 +508,41 @@ func ExampleGetSelf() {
 	//   - now I have access to the whole teacher
 }
 
+// Govy comes with a set of predefined rules,
+// which you can use out of the box by importing [rules] package.
+//
+// However, you can also create your own rules by using [govy.NewRule] constructor.
+// It accepts a simple validation function which takes in a value
+// and returns an error if the validation failed.
+//
+// Note: the [govy.Rule] struct has all its fields private,
+// so you can only create and modify them using exported constructor and methods.
+func ExampleRule() {
+	myRule := govy.NewRule(func(name string) error {
+		if name != "Tom" {
+			return fmt.Errorf("Teacher can be only Tom")
+		}
+		return nil
+	})
+	v := govy.New(
+		govy.For(func(t Teacher) string { return t.Name }).
+			WithName("name").
+			Rules(myRule),
+	)
+
+	teacher := Teacher{Name: "Jake"}
+
+	err := v.Validate(teacher)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// Validation has failed for the following properties:
+	//   - 'name' with value 'Jake':
+	//     - Teacher can be only Tom
+}
+
 // You can use [govy.Rule.WithDetails] to add additional details to the error message.
 // This allows you to extend existing rules by adding your use case context.
 // Let's give a regex validation some more clarity.
@@ -630,6 +665,39 @@ func ExampleRule_WithDescription() {
 	//     - unsupported name; Teacher can be either Tom or Jerry :)
 }
 
+// The builtin rules, and most likely your custom rules as well, all operate on non-pointer values.
+// This means you cannot use them on pointers to the same type.
+//
+// To solve this problem you can use [govy.ForPointer] constructor and convert any [govy.Rule]
+// to work on pointers.
+//
+// Note: [govy.ForPointer] will skip validation for nil pointers.
+// If you want to enforce the value to be non-nil, you can use [rules.Required].
+// This behaviour is consistent with [govy.ForPointer] constructor, which will skip the validation
+// unless you add [govy.PropertyRules.Required] to enforce the value to be a non-nil pointer.
+func ExampleRuleToPointer() {
+	type Pointer struct {
+		Pointer *string `json:"pointer"`
+	}
+	validator := govy.New(
+		govy.For(func(p Pointer) *string { return p.Pointer }).
+			WithName("pointer").
+			Rules(govy.RuleToPointer(rules.EQ("foo"))),
+	)
+
+	pointer := Pointer{Pointer: ptr("bar")}
+
+	err := validator.Validate(pointer)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// Validation has failed for the following properties:
+	//   - 'pointer' with value 'bar':
+	//     - should be equal to 'foo'
+}
+
 // Sometimes it's useful to aggregate multiple [govy.Rule] into a single, composite rule.
 // To do that we'll use [govy.RuleSet] and [govy.NewRuleSet] constructor.
 // RuleSet is a simple container for multiple [govy.Rule].
@@ -671,6 +739,38 @@ func ExampleRuleSet() {
 	//   - 'name' with value 'Jonathan':
 	//     - length must be between 1 and 5
 	//     - string must match regular expression: '^(Tom|Jerry)$'; Teacher can be either Tom or Jerry :)
+}
+
+// Similar to [govy.RuleToPointer], you can use [govy.RuleSetToPointer] to convert
+// [govy.RuleSet] to work with pointers.
+//
+// See [ExampleRuleToPointer] for more details.
+func ExampleRuleSetToPointer() {
+	type Pointer struct {
+		Pointer *string `json:"pointer"`
+	}
+	ruleSet := govy.NewRuleSet(
+		rules.StringStartsWith("f"),
+		rules.StringEndsWith("o"),
+	)
+	validator := govy.New(
+		govy.For(func(p Pointer) *string { return p.Pointer }).
+			WithName("pointer").
+			Rules(govy.RuleSetToPointer(ruleSet)),
+	)
+
+	pointer := Pointer{Pointer: ptr("bar")}
+
+	err := validator.Validate(pointer)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// Validation has failed for the following properties:
+	//   - 'pointer' with value 'bar':
+	//     - string must start with 'f' prefix
+	//     - string must end with 'o' suffix
 }
 
 // To inspect if an error contains a given [govy.ErrorCode], use [govy.HasErrorCode] function.
@@ -863,6 +963,65 @@ func ExampleForSlice() {
 	//     - elements are not unique, 1st and 3rd elements collide
 	//   - 'students[1].index' with value '9182300123':
 	//     - length must be between 9 and 9
+}
+
+// When dealing with slices of pointers you may find it problematic to add [govy.Rule]
+// with [govy.PropertyRulesForSlice.RulesForEach].
+// The builtin rules, and most likely your custom rules as well, all operate on non-pointer values.
+// This means you cannot use them on your slice's pointer elements.
+//
+// To solve this problem you can use [govy.ForPointer] constructor and convert any [govy.Rule]
+// to work on pointers.
+//
+// In the below example we're defining two [govy.Validator] instances:
+//   - 'faultyValidator' which will not fail for 'nil' value
+//   - 'goodValidator' which will fail for 'nil' value by using [rules.Required] rule
+//
+// This behaviour is consistent with [govy.ForPointer] constructor, which will skip the validation
+// unless you add [govy.PropertyRules.Required] to enforce the value to be a non-nil pointer.
+func ExampleForSlice_sliceOfPointers() {
+	type Pointers struct {
+		Pointers []*string `json:"pointers"`
+	}
+	pointersRules := govy.ForSlice(func(p Pointers) []*string { return p.Pointers }).
+		WithName("pointers").
+		Rules(rules.SliceMaxLength[[]*string](2)).
+		RulesForEach(
+			govy.RuleToPointer(rules.StringLength(9, 9)),
+		)
+	faultyValidator := govy.New(
+		pointersRules,
+	)
+	goodValidator := govy.New(
+		pointersRules.RulesForEach(rules.Required[*string]()),
+	)
+
+	pointers := Pointers{
+		Pointers: []*string{ptr("918230014"), ptr("9182300123"), ptr("918230014"), nil},
+	}
+
+	err := faultyValidator.Validate(pointers)
+	if err != nil {
+		fmt.Println(err)
+	}
+	err = goodValidator.Validate(pointers)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// Validation has failed for the following properties:
+	//   - 'pointers' with value '["918230014","9182300123","918230014",null]':
+	//     - length must be less than or equal to 2
+	//   - 'pointers[1]' with value '9182300123':
+	//     - length must be between 9 and 9
+	// Validation has failed for the following properties:
+	//   - 'pointers' with value '["918230014","9182300123","918230014",null]':
+	//     - length must be less than or equal to 2
+	//   - 'pointers[1]' with value '9182300123':
+	//     - length must be between 9 and 9
+	//   - 'pointers[3]':
+	//     - property is required but was empty
 }
 
 // When dealing with maps there are three forms of iteration:

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -673,7 +673,7 @@ func ExampleRule_WithDescription() {
 //
 // Note: [govy.RuleToPointer] will skip validation for nil pointers.
 // If you want to enforce the value to be non-nil, you can use [rules.Required].
-// This behaviour is consistent with [govy.ForPointer] constructor, which will skip the validation
+// This behavior is consistent with [govy.ForPointer] constructor, which will skip the validation
 // unless you add [govy.PropertyRules.Required] to enforce the value to be a non-nil pointer.
 func ExampleRuleToPointer() {
 	type Pointer struct {
@@ -977,7 +977,7 @@ func ExampleForSlice() {
 //   - 'faultyValidator' which will not fail for 'nil' value
 //   - 'goodValidator' which will fail for 'nil' value by using [rules.Required] rule
 //
-// This behaviour is consistent with [govy.ForPointer] constructor, which will skip the validation
+// This behavior is consistent with [govy.ForPointer] constructor, which will skip the validation
 // unless you add [govy.PropertyRules.Required] to enforce the value to be a non-nil pointer.
 func ExampleForSlice_sliceOfPointers() {
 	type Pointers struct {

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -668,10 +668,10 @@ func ExampleRule_WithDescription() {
 // The builtin rules, and most likely your custom rules as well, all operate on non-pointer values.
 // This means you cannot use them on pointers to the same type.
 //
-// To solve this problem you can use [govy.ForPointer] constructor and convert any [govy.Rule]
-// to work on pointers.
+// If for whatever reason you don't want to use [govy.ForPointer] constructor,
+// you can use [govy.RuleToPointer] constructor and convert any [govy.Rule] to work on pointers.
 //
-// Note: [govy.ForPointer] will skip validation for nil pointers.
+// Note: [govy.RuleToPointer] will skip validation for nil pointers.
 // If you want to enforce the value to be non-nil, you can use [rules.Required].
 // This behaviour is consistent with [govy.ForPointer] constructor, which will skip the validation
 // unless you add [govy.PropertyRules.Required] to enforce the value to be a non-nil pointer.

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -9,6 +9,25 @@ func NewRule[T any](validate func(v T) error) Rule[T] {
 	return Rule[T]{validate: validate}
 }
 
+// RuleToPointer converts an existing [Rule] to its pointer variant.
+// It retains all the properties of the original [Rule],
+// but modifies its type constraints to work with a pointer to the original type.
+// If the validated value is nil, the validation will be skipped.
+func RuleToPointer[T any](rule Rule[T]) Rule[*T] {
+	return Rule[*T]{
+		validate: func(v *T) error {
+			if v == nil {
+				return nil
+			}
+			return rule.validate(*v)
+		},
+		errorCode:   rule.errorCode,
+		details:     rule.details,
+		message:     rule.message,
+		description: rule.description,
+	}
+}
+
 // Rule is the basic validation building block.
 // It evaluates the provided validation function and enhances it
 // with optional [ErrorCode] and arbitrary details.

--- a/pkg/govy/rule_set_test.go
+++ b/pkg/govy/rule_set_test.go
@@ -42,3 +42,49 @@ func TestRuleSet(t *testing.T) {
 		assert.EqualError(t, errs[1], "string must end with 'bar' suffix")
 	})
 }
+
+func TestRuleSetWithErrorCode(t *testing.T) {
+	r := govy.NewRuleSet(
+		rules.StringStartsWith("foo"),
+		rules.StringEndsWith("bar"),
+	).
+		WithErrorCode("my-code")
+
+	err := r.Validate("baz_bar")
+
+	assert.Require(t, assert.Error(t, err))
+	errs := err.(govy.RuleSetError)
+	assert.Require(t, assert.Len(t, errs, 1))
+	ruleErr := errs[0].(*govy.RuleError)
+	assert.Equal(t, govy.RuleError{
+		Message:     "string must start with 'foo' prefix",
+		Code:        "my-code:string_starts_with",
+		Description: "string must start with 'foo' prefix",
+	}, *ruleErr)
+}
+
+func TestRuleSetToPointer(t *testing.T) {
+	r := govy.NewRuleSet(
+		rules.StringStartsWith("foo"),
+		rules.StringEndsWith("bar"),
+	).
+		WithErrorCode("my-code")
+	rp := govy.RuleSetToPointer(r)
+
+	t.Run("passes", func(t *testing.T) {
+		err := rp.Validate(ptr("foo+bar"))
+		assert.NoError(t, err)
+	})
+	t.Run("skip nil", func(t *testing.T) {
+		err := rp.Validate(nil)
+		assert.NoError(t, err)
+	})
+	t.Run("fails", func(t *testing.T) {
+		err := rp.Validate(ptr("baz-bar"))
+		assert.Require(t, assert.Error(t, err))
+		errs := err.(govy.RuleSetError)
+		assert.Require(t, assert.Len(t, errs, 1))
+		assert.EqualError(t, errs[0], "string must start with 'foo' prefix")
+		assert.Equal(t, "my-code:string_starts_with", errs[0].(*govy.RuleError).Code)
+	})
+}

--- a/pkg/govy/rule_test.go
+++ b/pkg/govy/rule_test.go
@@ -141,3 +141,26 @@ func TestRule_WithDescription(t *testing.T) {
 		Description: "the integer must be positive",
 	}, err)
 }
+
+func TestRuleToPointer(t *testing.T) {
+	r := govy.NewRule(func(v int) error {
+		if v < 0 {
+			return errors.New("must be positive")
+		}
+		return nil
+	}).
+		WithErrorCode("test")
+	rp := govy.RuleToPointer(r)
+	t.Run("passes", func(t *testing.T) {
+		err := rp.Validate(ptr(0))
+		assert.NoError(t, err)
+	})
+	t.Run("fails", func(t *testing.T) {
+		err := rp.Validate(ptr(-1))
+		assert.Require(t, assert.Error(t, err))
+		assert.Equal(t, govy.RuleError{
+			Message: "must be positive",
+			Code:    "test",
+		}, *err.(*govy.RuleError))
+	})
+}

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -6,7 +6,7 @@ import (
 )
 
 // validationInterface is a common interface implemented by all validation entities.
-// These include [Validator], [PropertyRules], and [Rule].
+// These include [Validator], [PropertyRules] and [Rule].
 type validationInterface[T any] interface {
 	Validate(s T) error
 }

--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -19,7 +19,8 @@ type testingT interface {
 // ExpectedRuleError defines the expectations for the asserted error.
 // Its fields are used to find and match an actual [govy.RuleError].
 type ExpectedRuleError struct {
-	// Required. Matched against [govy.PropertyError.PropertyName].
+	// Optional. Matched against [govy.PropertyError.PropertyName].
+	// It should be only left empty if the validate property has no name.
 	PropertyName string `json:"propertyName"`
 	// Optional. Matched against [govy.RuleError.Code].
 	Code govy.ErrorCode `json:"code,omitempty"`
@@ -33,9 +34,6 @@ type ExpectedRuleError struct {
 
 // expectedRuleErrorValidation defines the validation rules for [ExpectedRuleError].
 var expectedRuleErrorValidation = govy.New(
-	govy.For(func(e ExpectedRuleError) string { return e.PropertyName }).
-		WithName("propertyName").
-		Required(),
 	govy.For(govy.GetSelf[ExpectedRuleError]()).
 		Rules(rules.OneOfProperties(map[string]func(e ExpectedRuleError) any{
 			"code":            func(e ExpectedRuleError) any { return e.Code },

--- a/pkg/govytest/assert_test.go
+++ b/pkg/govytest/assert_test.go
@@ -49,8 +49,6 @@ func TestAssertError(t *testing.T) {
 			ok:             false,
 			expectedErrors: []govytest.ExpectedRuleError{{}},
 			out: `Validation for ExpectedRuleError has failed for the following properties:
-  - 'propertyName':
-    - property is required but was empty
   - one of [code, containsMessage, message] properties must be set, none was provided`,
 		},
 		"nil error": {


### PR DESCRIPTION
## Motivation

While we already have ways of handling pointers, most notably `ForPointer` constructor, there are cases where we have to operate on a pointer and use predefined rules to validate it.
This is specifically the case with slices of pointers where we cannot use `ForPointer` as we're already operating on `RulesForSlice` instance.

## Summary

- Added two converter functions for both `govy.Rule` and `govy.RuleSet` which convert them to work on pointers.
- Changed `govy.NewRuleSet` constructor to only accept `govy.Rule`.
- Removed requirement to provide property name for `govytest.ExpectedRuleError`.
- Improved examples.
- Extended tests.

## Release Notes

Added two functions: `govy.RuleToPointer` and `govy.RuleSetToPointer` which both convert respectively `govy.Rule[T]` and `govy.RuleSet[T]` to work on pointers of the same type: `govy.Rule[*T]` and `govy.RuleSet[*T]`.
`govytest.ExpectedRuleError` no longer requires `PropertyName` to be provided, this allows testing properties which have no name.

## Breaking Changes

`govy.NewRuleSet` now only accepts `govy.Rule`. Previously passing anything else into it would not work either.
