### PR TITLE
feat: Add cascade mode setting to Validator

### DIFF
--- a/pkg/govy/cascade_mode.go
+++ b/pkg/govy/cascade_mode.go
@@ -5,7 +5,7 @@ type CascadeMode uint
 
 const (
 	// CascadeModeContinue will continue validation after first error.
-	CascadeModeContinue CascadeMode = iota
+	CascadeModeContinue CascadeMode = iota + 1
 	// CascadeModeStop will stop validation on first error encountered.
 	CascadeModeStop
 )

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -220,6 +220,16 @@ func (r PropertyRules[T, S]) Cascade(mode CascadeMode) PropertyRules[T, S] {
 	return r
 }
 
+// cascadeInternal is an internal wrapper around [PropertyRules.Cascade] which
+// fulfills [propertyRulesInterface] interface.
+// If the [CascadeMode] is already set, it won't change it.
+func (r PropertyRules[T, S]) cascadeInternal(mode CascadeMode) propertyRulesInterface[S] {
+	if r.mode != 0 {
+		return r
+	}
+	return r.Cascade(mode)
+}
+
 // plan constructs a validation plan for the property.
 func (r PropertyRules[T, S]) plan(builder planBuilder) {
 	builder.propertyPlan.IsOptional = (r.omitEmpty || r.isPointer) && !r.required

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -177,6 +177,16 @@ func (r PropertyRulesForMap[M, K, V, S]) Cascade(mode CascadeMode) PropertyRules
 	return r
 }
 
+// cascadeInternal is an internal wrapper around [PropertyRulesForMap.Cascade] which
+// fulfills [propertyRulesInterface] interface.
+// If the [CascadeMode] is already set, it won't change it.
+func (r PropertyRulesForMap[M, K, V, S]) cascadeInternal(mode CascadeMode) propertyRulesInterface[S] {
+	if r.mode != 0 {
+		return r
+	}
+	return r.Cascade(mode)
+}
+
 // plan constructs a validation plan for the property rules.
 func (r PropertyRulesForMap[M, K, V, S]) plan(builder planBuilder) {
 	for _, predicate := range r.predicates {

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -109,6 +109,16 @@ func (r PropertyRulesForSlice[T, S]) Cascade(mode CascadeMode) PropertyRulesForS
 	return r
 }
 
+// cascadeInternal is an internal wrapper around [PropertyRulesForMap.Cascade] which
+// fulfills [propertyRulesInterface] interface.
+// If the [CascadeMode] is already set, it won't change it.
+func (r PropertyRulesForSlice[T, S]) cascadeInternal(mode CascadeMode) propertyRulesInterface[S] {
+	if r.mode != 0 {
+		return r
+	}
+	return r.Cascade(mode)
+}
+
 // plan generates a validation plan for the property rules.
 func (r PropertyRulesForSlice[T, S]) plan(builder planBuilder) {
 	for _, predicate := range r.predicates {

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -11,8 +11,19 @@ type validationInterface[T any] interface {
 	Validate(s T) error
 }
 
+// propertyRulesInterface is an internal interface which further limits
+// what [New] constructor and [Validator] can accept as property rules.
+//
+// On top of [validationInterface] requirements it specifies internal functions
+// which allow interacting with [propertyRulesInterface] instances like [PropertyRules]
+// in an immutable fashion (no pointer receivers).
+type propertyRulesInterface[T any] interface {
+	validationInterface[T]
+	cascadeInternal(mode CascadeMode) propertyRulesInterface[T]
+}
+
 // New creates a new [Validator] aggregating the provided property rules.
-func New[S any](props ...validationInterface[S]) Validator[S] {
+func New[S any](props ...propertyRulesInterface[S]) Validator[S] {
 	return Validator[S]{props: props}
 }
 
@@ -20,9 +31,10 @@ func New[S any](props ...validationInterface[S]) Validator[S] {
 // It serves as an aggregator for [PropertyRules].
 // Typically, it represents a struct.
 type Validator[S any] struct {
-	props    []validationInterface[S]
+	props    []propertyRulesInterface[S]
 	name     string
 	nameFunc func(S) string
+	mode     CascadeMode
 
 	predicateMatcher[S]
 }
@@ -64,6 +76,18 @@ func (v Validator[S]) InferName() Validator[S] {
 	return v
 }
 
+// Cascade sets the [CascadeMode] for the validator,
+// which controls the flow of evaluating the validation rules.
+func (v Validator[S]) Cascade(mode CascadeMode) Validator[S] {
+	v.mode = mode
+	props := make([]propertyRulesInterface[S], 0, len(v.props))
+	for _, prop := range v.props {
+		props = append(props, prop.cascadeInternal(mode))
+	}
+	v.props = props
+	return v
+}
+
 // Validate will first evaluate predicates before validating any rules.
 // If any predicate does not pass the validation won't be executed (returns nil).
 // All errors returned by property rules will be aggregated and wrapped in [ValidatorError].
@@ -83,6 +107,9 @@ func (v Validator[S]) Validate(st S) error {
 			continue
 		}
 		allErrors = append(allErrors, pErrs...)
+		if v.mode == CascadeModeStop {
+			break
+		}
 	}
 	if len(allErrors) != 0 {
 		name := v.name


### PR DESCRIPTION
## Summary

Added `govy.Validator.Cascade` which allows setting cascade mode on Validator level and influencing property rules behavior.

## Release Notes

Added `govy.Validator.Cascade` which allows controlling error handling on `govy.Validator` level and propagating the setting to `govy.PropertyRules`. For more details on cascade mode read [this](https://pkg.go.dev/github.com/nobl9/govy@v0.6.0/pkg/govy#CascadeMode).

## Breaking Changes

`govy.CascadeMode` enum now starts from 1 (previously 0).