### PR TITLE
chore: Fix benchamrk action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,10 @@ jobs:
           github-token: ${{ secrets.GO_BENCHMARK_TOKEN }}
           # We update GitHub pages only on on 'push' events below.
           auto-push: false
+      - name: Check out gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
       - name: Push benchmark result
         if: github.event_name == 'push'
         run: git push 'https://nobl9:${{ secrets.GO_BENCHMARK_TOKEN }}@github.com/nobl9/govy.git' gh-pages:gh-pages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-      - name: Push benchmark result
         if: github.event_name == 'push'
+      - name: Push benchmark result
         run: git push 'https://nobl9:${{ secrets.GO_BENCHMARK_TOKEN }}@github.com/nobl9/govy.git' gh-pages:gh-pages
+        if: github.event_name == 'push'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
           github-token: ${{ secrets.GO_BENCHMARK_TOKEN }}
           # We update GitHub pages only on on 'push' events below.
           auto-push: false
-      - name: Check out gh-pages branch
+      - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
           ref: gh-pages


### PR DESCRIPTION
## Summary

Since we're using [checkout action](https://github.com/actions/checkout) with no parameters it fetches only the `github.ref` branch, in case of push to `main` it will be just `main`. We need to fetch `gh-pages` ref first, before we proceed with pushing to it.
