### PR TITLE
chore: Split test workflows for pushes to main

### DIFF
--- a/.github/workflows/coverage-and-benchmark.yml
+++ b/.github/workflows/coverage-and-benchmark.yml
@@ -1,10 +1,11 @@
-name: Tests
+name: Coverage and Benchmark
 on:
-  pull_request:
+  push:
     branches:
       - main
 permissions:
-  pull-requests: write
+  deployments: write
+  contents: write
 jobs:
   test:
     name: Run unit tests
@@ -16,25 +17,25 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.11.0
         with:
           enable-cache: true
-      - name: Run unit tests
-        run: devbox run -- make test
+      - name: Update coverage report
+        uses: ncruces/go-coverage-report@v0
+        with:
+          report: true
+          chart: true
+          amend: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GO_COVERAGE_TOKEN }}
+        continue-on-error: true
       - name: Run benchmark
         run: make test/benchmark | tee benchmark.txt
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-      - name: Store benchmark result
+      - name: Publish benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Govy Go Benchmark
           tool: 'go'
-          alert-threshold: '150%'
           output-file-path: benchmark.txt
-          external-data-json-path: ./cache/benchmark-data.json
           fail-on-alert: false
-          # Commit comment.
-          comment-on-alert: true
-          alert-comment-cc-users: '@nieomylnieja'
+          auto-push: true
+          gh-pages-branch: gh-pages
+          skip-fetch-gh-pages: false
           github-token: ${{ secrets.GO_BENCHMARK_TOKEN }}


### PR DESCRIPTION
## Summary

Currently we're adding `if` statements to assert a GitHub event is equal to `push` to run some of the push-only actions.
This is not ideal as we're introducing misconfiguration potential and elevate the job's permissions.
Furthermore, it seems that it might be easier to configure [benchmark action](https://github.com/benchmark-action/github-action-benchmark) separately for publishing GitHub Pages and for checking the PR.