### PR TITLE
feat: Add StringDateTime and StringTimeZone rules

### DIFF
--- a/pkg/rules/error_codes.go
+++ b/pkg/rules/error_codes.go
@@ -45,6 +45,8 @@ const (
 	ErrorCodeStringDirPath             govy.ErrorCode = "string_dir_path"
 	ErrorCodeStringRegexp              govy.ErrorCode = "string_regexp"
 	ErrorCodeStringCrontab             govy.ErrorCode = "string_crontab"
+	ErrorCodeStringDateTime            govy.ErrorCode = "string_date_time"
+	ErrorCodeStringTimeZone            govy.ErrorCode = "string_time_zone"
 	ErrorCodeSliceLength               govy.ErrorCode = "slice_length"
 	ErrorCodeSliceMinLength            govy.ErrorCode = "slice_min_length"
 	ErrorCodeSliceMaxLength            govy.ErrorCode = "slice_max_length"


### PR DESCRIPTION
## Release Notes

Added `StringDateTime` rule which ensures a string is a valid date and time according to the rules defined by https://pkg.go.dev/time.
Added `StringTimeZone` rule which ensures a string is a valid IANA Time Zone database code.
