### PR TITLE
fix: Predicate matching for govy.PropertyRules

### DIFF
--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -106,6 +106,9 @@ type PropertyRules[T, S any] struct {
 
 // Validate validates the property value using provided rules.
 func (r PropertyRules[T, S]) Validate(st S) error {
+	if !r.matchPredicates(st) {
+		return nil
+	}
 	var (
 		ruleErrors []error
 		allErrors  PropertyErrors
@@ -118,9 +121,6 @@ func (r PropertyRules[T, S]) Validate(st S) error {
 		return PropertyErrors{propErr}
 	}
 	if skip {
-		return nil
-	}
-	if !r.matchPredicates(st) {
 		return nil
 	}
 	for _, step := range r.steps {

--- a/pkg/govy/rules_test.go
+++ b/pkg/govy/rules_test.go
@@ -221,6 +221,15 @@ func TestRequiredAndOmitEmpty(t *testing.T) {
 			assert.True(t, govy.HasErrorCode(errs, rules.ErrorCodeStringMinLength))
 		})
 	})
+
+	t.Run("required with when condition", func(t *testing.T) {
+		r := govy.ForPointer(func(s *string) *string { return s }).
+			When(func(s *string) bool { return s != nil }).
+			Required().
+			Rules(rules.StringMinLength(10))
+		err := r.Validate(nil)
+		assert.NoError(t, err)
+	})
 }
 
 func TestTransform(t *testing.T) {


### PR DESCRIPTION
## Summary

`PropertyRulesForMap` and `PropertyRulesForSlice` already had the predicates matching done before a value getter was called.
Having this check done for `PropertyRules` **AFTER** extracting the value was causing `Required` to fail with an error before any conditions were checked.

Example of such scenario:

```go
r := govy.ForPointer(func(s *string) *string { return s }).
	When(func(s *string) bool { return s != nil }).
	Required().
	Rules(rules.StringMinLength(10))
err := r.Validate(nil)
assert.NoError(t, err) // Fails!
```

## Breaking Changes

`govy.PropertyRules` will no longer fail if `Required()` was specified when a validate value is its type's zero value **AND** none of the `When()` conditions are matched.
