### PR TITLE
chore: Remove details from govy.RuleError

### DIFF
--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -211,19 +211,12 @@ func NewRuleError(message string, codes ...ErrorCode) *RuleError {
 type RuleError struct {
 	Message     string    `json:"error"`
 	Code        ErrorCode `json:"code,omitempty"`
-	Details     string    `json:"details,omitempty"`
 	Description string    `json:"description,omitempty"`
 }
 
 // Error implements the error interface.
 func (r *RuleError) Error() string {
-	if r.Details == "" {
-		return r.Message
-	}
-	if r.Message == "" {
-		return r.Details
-	}
-	return r.Message + "; " + r.Details
+	return r.Message
 }
 
 // AddCode extends the [RuleError] with the given error code.

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -50,9 +50,8 @@ func (r Rule[T]) Validate(v T) error {
 		switch ev := err.(type) {
 		case *RuleError:
 			if len(r.message) > 0 {
-				ev.Message = r.message
+				ev.Message = addDetailsToErrorMessage(r.message, r.details)
 			}
-			ev.Details = r.details
 			ev.Description = r.description
 			return ev.AddCode(r.errorCode)
 		case *PropertyError:
@@ -66,9 +65,8 @@ func (r Rule[T]) Validate(v T) error {
 				msg = r.message
 			}
 			return &RuleError{
-				Message:     msg,
+				Message:     addDetailsToErrorMessage(msg, r.details),
 				Code:        r.errorCode,
-				Details:     r.details,
 				Description: r.description,
 			}
 		}
@@ -117,4 +115,14 @@ func (r Rule[T]) plan(builder planBuilder) {
 		Conditions:  builder.rulePlan.Conditions,
 	}
 	*builder.children = append(*builder.children, builder)
+}
+
+func addDetailsToErrorMessage(message, details string) string {
+	if details == "" {
+		return message
+	}
+	if message == "" {
+		return details
+	}
+	return message + "; " + details
 }

--- a/pkg/govy/rule_test.go
+++ b/pkg/govy/rule_test.go
@@ -135,9 +135,8 @@ func TestRule_WithDescription(t *testing.T) {
 	err := r.Validate(-1)
 	assert.Require(t, assert.Error(t, err))
 	assert.Equal(t, &govy.RuleError{
-		Message:     "must be positive",
+		Message:     "must be positive; some details",
 		Code:        "test",
-		Details:     "some details",
 		Description: "the integer must be positive",
 	}, err)
 }

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -943,10 +943,10 @@ func TestStringGitRef(t *testing.T) {
 			if tc.expectedErr != nil {
 				assert.ErrorContains(t, err, tc.expectedErr.Error())
 				assert.True(t, govy.HasErrorCode(err, ErrorCodeStringGitRef))
-				assert.Equal(
+				assert.ErrorContains(
 					t,
+					err,
 					"see https://git-scm.com/docs/git-check-ref-format for more information on Git reference naming rules",
-					err.(*govy.RuleError).Details,
 				)
 			} else {
 				assert.NoError(t, err)


### PR DESCRIPTION
## Motivation

We're moving towards a more unified error message creation. The goal is to allow users to manipulate the error message however they see fit. With that in mind, `govy.RuleError` should have its `Message` field populated with a created error that is ready to be used as is and passed downstream.

## Related Changes

- https://github.com/nobl9/govy/pull/10
- https://github.com/nobl9/govy/pull/59

## Breaking Changes

Removed `govy.RuleError.Details` field, the error's details are now part of the `govy.RuleError.Message` and not just the `govy.RuleError.Error()` output.
