### PR TITLE
chore: Correct benchmarks

### DIFF
--- a/pkg/rules/comparable_test.go
+++ b/pkg/rules/comparable_test.go
@@ -31,9 +31,10 @@ func TestEQ(t *testing.T) {
 }
 
 func BenchmarkEQ(b *testing.B) {
-	for range b.N {
-		for _, tc := range eqTestCases {
-			_ = EQ(tc.value).Validate(tc.input)
+	for _, tc := range eqTestCases {
+		rule := EQ(tc.value)
+		for range b.N {
+			_ = rule.Validate(tc.input)
 		}
 	}
 }
@@ -61,9 +62,10 @@ func TestNEQ(t *testing.T) {
 }
 
 func BenchmarkNEQ(b *testing.B) {
-	for range b.N {
-		for _, tc := range neqTestCases {
-			_ = NEQ(tc.value).Validate(tc.input)
+	for _, tc := range neqTestCases {
+		rule := NEQ(tc.value)
+		for range b.N {
+			_ = rule.Validate(tc.input)
 		}
 	}
 }
@@ -92,9 +94,10 @@ func TestGT(t *testing.T) {
 }
 
 func BenchmarkGT(b *testing.B) {
-	for range b.N {
-		for _, tc := range gtTestCases {
-			_ = GT(tc.value).Validate(tc.input)
+	for _, tc := range gtTestCases {
+		rule := GT(tc.value)
+		for range b.N {
+			_ = rule.Validate(tc.input)
 		}
 	}
 }
@@ -123,9 +126,10 @@ func TestGTE(t *testing.T) {
 }
 
 func BenchmarkGTE(b *testing.B) {
-	for range b.N {
-		for _, tc := range gteTestCases {
-			_ = GTE(tc.value).Validate(tc.input)
+	for _, tc := range gteTestCases {
+		rule := GTE(tc.value)
+		for range b.N {
+			_ = rule.Validate(tc.input)
 		}
 	}
 }
@@ -154,9 +158,10 @@ func TestLT(t *testing.T) {
 }
 
 func BenchmarkLT(b *testing.B) {
-	for range b.N {
-		for _, tc := range ltTestCases {
-			_ = LT(tc.value).Validate(tc.input)
+	for _, tc := range ltTestCases {
+		rule := LT(tc.value)
+		for range b.N {
+			_ = rule.Validate(tc.input)
 		}
 	}
 }
@@ -185,9 +190,10 @@ func TestLTE(t *testing.T) {
 }
 
 func BenchmarkLTE(b *testing.B) {
-	for range b.N {
-		for _, tc := range lteTestCases {
-			_ = LTE(tc.value).Validate(tc.input)
+	for _, tc := range lteTestCases {
+		rule := LTE(tc.value)
+		for range b.N {
+			_ = rule.Validate(tc.input)
 		}
 	}
 }
@@ -259,9 +265,10 @@ func TestEqualProperties(t *testing.T) {
 }
 
 func BenchmarkEqualProperties(b *testing.B) {
-	for range b.N {
-		for _, tc := range equalPropertiesTestCases {
-			_ = tc.run()
+	for _, tc := range equalPropertiesTestCases {
+		rule := tc.run()
+		for range b.N {
+			_ = rule
 		}
 	}
 }

--- a/pkg/rules/duration_test.go
+++ b/pkg/rules/duration_test.go
@@ -56,9 +56,10 @@ func TestDurationPrecision(t *testing.T) {
 }
 
 func BenchmarkDurationPrecision(b *testing.B) {
-	for range b.N {
-		for _, tc := range durationPrecisionTestCases {
-			_ = DurationPrecision(tc.precision).Validate(tc.duration)
+	for _, tc := range durationPrecisionTestCases {
+		rule := DurationPrecision(tc.precision)
+		for range b.N {
+			_ = rule.Validate(tc.duration)
 		}
 	}
 }

--- a/pkg/rules/forbidden_test.go
+++ b/pkg/rules/forbidden_test.go
@@ -29,9 +29,10 @@ func TestForbidden(t *testing.T) {
 }
 
 func BenchmarkForbidden(b *testing.B) {
-	for range b.N {
-		for _, tc := range forbiddenTestCases {
-			_ = Forbidden[string]().Validate(tc.in)
+	for _, tc := range forbiddenTestCases {
+		rule := Forbidden[string]()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }

--- a/pkg/rules/length_test.go
+++ b/pkg/rules/length_test.go
@@ -41,9 +41,10 @@ func TestStringLength(t *testing.T) {
 }
 
 func BenchmarkStringLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringLengthTestCases {
-			_ = StringLength(tc.minLen, tc.maxLen).Validate(tc.value)
+	for _, tc := range stringLengthTestCases {
+		rule := StringLength(tc.minLen, tc.maxLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -73,9 +74,10 @@ func TestStringMinLength(t *testing.T) {
 }
 
 func BenchmarkStringMinLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringMinLengthTestCases {
-			_ = StringMinLength(tc.minLen).Validate(tc.value)
+	for _, tc := range stringMinLengthTestCases {
+		rule := StringMinLength(tc.minLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -105,9 +107,10 @@ func TestStringMaxLength(t *testing.T) {
 }
 
 func BenchmarkStringMaxLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringMaxLengthTestCases {
-			_ = StringMaxLength(tc.maxLen).Validate(tc.value)
+	for _, tc := range stringMaxLengthTestCases {
+		rule := StringMaxLength(tc.maxLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -145,9 +148,10 @@ func TestSliceLength(t *testing.T) {
 }
 
 func BenchmarkSliceLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range sliceLengthTestCases {
-			_ = SliceLength[[]string](tc.minLen, tc.maxLen).Validate(tc.value)
+	for _, tc := range sliceLengthTestCases {
+		rule := SliceLength[[]string](tc.minLen, tc.maxLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -177,9 +181,10 @@ func TestSliceMinLength(t *testing.T) {
 }
 
 func BenchmarkSliceMinLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range sliceMinLengthTestCases {
-			_ = SliceMinLength[[]string](tc.minLen).Validate(tc.value)
+	for _, tc := range sliceMinLengthTestCases {
+		rule := SliceMinLength[[]string](tc.minLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -209,9 +214,10 @@ func TestSliceMaxLength(t *testing.T) {
 }
 
 func BenchmarkSliceMaxLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range sliceMaxLengthTestCases {
-			_ = SliceMaxLength[[]string](tc.maxLen).Validate(tc.value)
+	for _, tc := range sliceMaxLengthTestCases {
+		rule := SliceMaxLength[[]string](tc.maxLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -262,9 +268,10 @@ func TestMapLength(t *testing.T) {
 }
 
 func BenchmarkMapLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range mapLengthTestCases {
-			_ = MapLength[map[string]string](tc.minLen, tc.maxLen).Validate(tc.value)
+	for _, tc := range mapLengthTestCases {
+		rule := MapLength[map[string]string](tc.minLen, tc.maxLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -302,9 +309,10 @@ func TestMapMinLength(t *testing.T) {
 }
 
 func BenchmarkMapMinLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range mapMinLengthTestCases {
-			_ = MapMinLength[map[string]string](tc.minLen).Validate(tc.value)
+	for _, tc := range mapMinLengthTestCases {
+		rule := MapMinLength[map[string]string](tc.minLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }
@@ -342,9 +350,10 @@ func TestMapMaxLength(t *testing.T) {
 }
 
 func BenchmarkMapMaxLength(b *testing.B) {
-	for range b.N {
-		for _, tc := range mapMaxLengthTestCases {
-			_ = MapMaxLength[map[string]string](tc.maxLen).Validate(tc.value)
+	for _, tc := range mapMaxLengthTestCases {
+		rule := MapMaxLength[map[string]string](tc.maxLen)
+		for range b.N {
+			_ = rule.Validate(tc.value)
 		}
 	}
 }

--- a/pkg/rules/one_of_test.go
+++ b/pkg/rules/one_of_test.go
@@ -37,9 +37,10 @@ type paymentMethod struct {
 }
 
 func BenchmarkOneOf(b *testing.B) {
-	for range b.N {
-		for _, tc := range oneOfTestCases {
-			_ = OneOf(tc.options...).Validate(tc.in)
+	for _, tc := range oneOfTestCases {
+		rule := OneOf(tc.options...)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -131,9 +132,10 @@ func TestMutuallyExclusive(t *testing.T) {
 }
 
 func BenchmarkMutuallyExclusive(b *testing.B) {
-	for range b.N {
-		for _, tc := range mutuallyExclusiveTestCases {
-			_ = MutuallyExclusive(tc.required, paymentMethodGetters).Validate(tc.paymentMethod)
+	for _, tc := range mutuallyExclusiveTestCases {
+		rule := MutuallyExclusive(tc.required, paymentMethodGetters)
+		for range b.N {
+			_ = rule.Validate(tc.paymentMethod)
 		}
 	}
 }
@@ -186,9 +188,10 @@ func TestOneOfProperties(t *testing.T) {
 }
 
 func BenchmarkOneOfProperties(b *testing.B) {
-	for range b.N {
-		for _, tc := range oneOfPropertiesTestCases {
-			_ = OneOfProperties(paymentMethodGetters).Validate(tc.paymentMethod)
+	for _, tc := range oneOfPropertiesTestCases {
+		rule := OneOfProperties(paymentMethodGetters)
+		for range b.N {
+			_ = rule.Validate(tc.paymentMethod)
 		}
 	}
 }

--- a/pkg/rules/required_test.go
+++ b/pkg/rules/required_test.go
@@ -38,9 +38,10 @@ func TestRequired(t *testing.T) {
 }
 
 func BenchmarkRequired(b *testing.B) {
-	for range b.N {
-		for _, tc := range requiredTestCases {
-			_ = Required[any]().Validate(tc.in)
+	for _, tc := range requiredTestCases {
+		rule := Required[any]()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -37,9 +37,10 @@ func TestStringNotEmpty(t *testing.T) {
 }
 
 func BenchmarkStringNotEmpty(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringNotEmptyTestCases {
-			_ = StringNotEmpty().Validate(tc.in)
+	for _, tc := range stringNotEmptyTestCases {
+		rule := StringNotEmpty()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -73,9 +74,10 @@ func TestStringMatchRegexp(t *testing.T) {
 }
 
 func BenchmarkStringMatchRegexp(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringMatchRegexpTestCases {
-			_ = StringMatchRegexp(stringMatchRegexpRegexp).Validate(tc.in)
+	for _, tc := range stringMatchRegexpTestCases {
+		rule := StringMatchRegexp(stringMatchRegexpRegexp)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -109,9 +111,10 @@ func TestStringDenyRegexp(t *testing.T) {
 }
 
 func BenchmarkStringDenyRegexp(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringDenyRegexpTestCases {
-			_ = StringDenyRegexp(stringDenyRegexpRegexp).Validate(tc.in)
+	for _, tc := range stringDenyRegexpTestCases {
+		rule := StringDenyRegexp(stringDenyRegexpRegexp)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -151,9 +154,10 @@ func TestStringDNSLabel(t *testing.T) {
 }
 
 func BenchmarkStringDNSLabel(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringDNSLabelTestCases {
-			_ = StringDNSLabel().Validate(tc.in)
+	for _, tc := range stringDNSLabelTestCases {
+		rule := StringDNSLabel()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -190,9 +194,10 @@ func TestStringASCII(t *testing.T) {
 }
 
 func BenchmarkStringASCII(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringASCIITestCases {
-			_ = StringASCII().Validate(tc.in)
+	for _, tc := range stringASCIITestCases {
+		rule := StringASCII()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -233,9 +238,10 @@ func TestStringUUID(t *testing.T) {
 }
 
 func BenchmarkStringUUID(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringUUIDTestCases {
-			_ = StringUUID().Validate(tc.in)
+	for _, tc := range stringUUIDTestCases {
+		rule := StringUUID()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -277,9 +283,10 @@ func TestStringEmail(t *testing.T) {
 }
 
 func BenchmarkStringEmail(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringEmailTestCases {
-			_ = StringEmail().Validate(tc.in)
+	for _, tc := range stringEmailTestCases {
+		rule := StringEmail()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -306,9 +313,10 @@ func TestStringURL(t *testing.T) {
 }
 
 func BenchmarkStringURL(b *testing.B) {
-	for range b.N {
-		for _, tc := range urlTestCases {
-			_ = StringURL().Validate(tc.url)
+	for _, tc := range urlTestCases {
+		rule := StringURL()
+		for range b.N {
+			_ = rule.Validate(tc.url)
 		}
 	}
 }
@@ -341,9 +349,10 @@ func TestStringMAC(t *testing.T) {
 }
 
 func BenchmarkStringMAC(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringMACTestCases {
-			_ = StringMAC().Validate(tc.in)
+	for _, tc := range stringMACTestCases {
+		rule := StringMAC()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -380,9 +389,10 @@ func TestStringIP(t *testing.T) {
 }
 
 func BenchmarkStringIP(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringIPTestCases {
-			_ = StringIP().Validate(tc.in)
+	for _, tc := range stringIPTestCases {
+		rule := StringIP()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -418,9 +428,10 @@ func TestStringIPv4(t *testing.T) {
 }
 
 func BenchmarkStringIPv4(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringIPv4TestCases {
-			_ = StringIPv4().Validate(tc.in)
+	for _, tc := range stringIPv4TestCases {
+		rule := StringIPv4()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -456,9 +467,10 @@ func TestStringIPv6(t *testing.T) {
 }
 
 func BenchmarkStringIPv6(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringIPv6TestCases {
-			_ = StringIPv6().Validate(tc.in)
+	for _, tc := range stringIPv6TestCases {
+		rule := StringIPv6()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -497,9 +509,10 @@ func TestStringCIDR(t *testing.T) {
 }
 
 func BenchmarkStringCIDR(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringCIDRTestCases {
-			_ = StringCIDR().Validate(tc.in)
+	for _, tc := range stringCIDRTestCases {
+		rule := StringCIDR()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -545,9 +558,10 @@ func TestStringCIDRv4(t *testing.T) {
 }
 
 func BenchmarkStringCIDRv4(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringCIDRv4TestCases {
-			_ = StringCIDRv4().Validate(tc.in)
+	for _, tc := range stringCIDRv4TestCases {
+		rule := StringCIDRv4()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -586,9 +600,10 @@ func TestStringCIDRv6(t *testing.T) {
 }
 
 func BenchmarkStringCIDRv6(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringCIDRv6TestCases {
-			_ = StringCIDRv6().Validate(tc.in)
+	for _, tc := range stringCIDRv6TestCases {
+		rule := StringCIDRv6()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -618,9 +633,10 @@ func TestStringJSON(t *testing.T) {
 }
 
 func BenchmarkStringJSON(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringJSONTestCases {
-			_ = StringJSON().Validate(tc.in)
+	for _, tc := range stringJSONTestCases {
+		rule := StringJSON()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -676,9 +692,10 @@ func TestStringContains(t *testing.T) {
 }
 
 func BenchmarkStringContains(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringContainsTestCases {
-			_ = StringContains(tc.substrings...).Validate(tc.in)
+	for _, tc := range stringContainsTestCases {
+		rule := StringContains(tc.substrings...)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -735,9 +752,10 @@ func TestStringExcludes(t *testing.T) {
 }
 
 func BenchmarkStringExcludes(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringExcludesTestCases {
-			_ = StringExcludes(tc.substrings...).Validate(tc.in)
+	for _, tc := range stringExcludesTestCases {
+		rule := StringExcludes(tc.substrings...)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -780,9 +798,10 @@ func TestStringStartsWith(t *testing.T) {
 }
 
 func BenchmarkStringStartsWith(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringStartsWithTestCases {
-			_ = StringStartsWith(tc.prefixes...).Validate(tc.in)
+	for _, tc := range stringStartsWithTestCases {
+		rule := StringStartsWith(tc.prefixes...)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -825,9 +844,10 @@ func TestStringEndsWith(t *testing.T) {
 }
 
 func BenchmarkStringEndsWith(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringEndsWithTestCases {
-			_ = StringEndsWith(tc.suffixes...).Validate(tc.in)
+	for _, tc := range stringEndsWithTestCases {
+		rule := StringEndsWith(tc.suffixes...)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -867,9 +887,10 @@ func TestStringTitle(t *testing.T) {
 }
 
 func BenchmarkStringTitle(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringTitleTestCases {
-			_ = StringTitle().Validate(tc.in)
+	for _, tc := range stringTitleTestCases {
+		rule := StringTitle()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -944,9 +965,10 @@ func TestStringGitRef(t *testing.T) {
 }
 
 func BenchmarkStringGitRef(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringGitRefTestCases {
-			_ = StringGitRef().Validate(tc.in)
+	for _, tc := range stringGitRefTestCases {
+		rule := StringGitRef()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1025,9 +1047,10 @@ func TestStringFileSystemPath(t *testing.T) {
 func BenchmarkStringFileSystemPath(b *testing.B) {
 	root := prepareFileSystemTests(b)
 	testCases := getStringFileSystemPathTestCases(root)
-	for range b.N {
-		for _, tc := range testCases {
-			_ = StringFileSystemPath().Validate(tc.in)
+	for _, tc := range testCases {
+		rule := StringFileSystemPath()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1075,9 +1098,10 @@ func TestStringFilePath(t *testing.T) {
 func BenchmarkStringFilePath(b *testing.B) {
 	root := prepareFileSystemTests(b)
 	testCases := getStringFilePathTestCases(root)
-	for range b.N {
-		for _, tc := range testCases {
-			_ = StringFilePath().Validate(tc.in)
+	for _, tc := range testCases {
+		rule := StringFilePath()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1125,9 +1149,10 @@ func TestStringDirPath(t *testing.T) {
 func BenchmarkStringDirPath(b *testing.B) {
 	root := prepareFileSystemTests(b)
 	testCases := getStringDirPathTestCases(root)
-	for range b.N {
-		for _, tc := range testCases {
-			_ = StringDirPath().Validate(tc.in)
+	for _, tc := range testCases {
+		rule := StringDirPath()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1213,9 +1238,10 @@ func TestStringMatchFileSystemPath(t *testing.T) {
 }
 
 func BenchmarkStringMatchFileSystemPath(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringMatchFileSystemPathTestCases {
-			_ = StringMatchFileSystemPath(tc.pattern).Validate(tc.in)
+	for _, tc := range stringMatchFileSystemPathTestCases {
+		rule := StringMatchFileSystemPath(tc.pattern)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1271,9 +1297,10 @@ func TestStringRegexp(t *testing.T) {
 }
 
 func BenchmarkStringRegexp(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringRegexpTestCases {
-			_ = StringRegexp().Validate(tc.in)
+	for _, tc := range stringRegexpTestCases {
+		rule := StringRegexp()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1410,8 +1437,8 @@ func TestStringCrontab(t *testing.T) {
 }
 
 func BenchmarkStringCrontab(b *testing.B) {
-	testCases := getStringCronTestCases()
 	for range b.N {
+		testCases := getStringCronTestCases()
 		for _, tc := range testCases {
 			_ = StringCrontab().Validate(tc.in)
 		}
@@ -1460,9 +1487,10 @@ func TestStringDateTime(t *testing.T) {
 }
 
 func BenchmarkStringDateTime(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringDateTimeTestCases {
-			_ = StringDateTime(tc.layout).Validate(tc.in)
+	for _, tc := range stringDateTimeTestCases {
+		rule := StringDateTime(tc.layout)
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1496,9 +1524,10 @@ func TestStringTimeZone(t *testing.T) {
 }
 
 func BenchmarkStringTimeZone(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringDateTimeTestCases {
-			_ = StringTimeZone().Validate(tc.in)
+	for _, tc := range stringDateTimeTestCases {
+		rule := StringTimeZone()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1534,9 +1563,10 @@ func TestStringAlpha(t *testing.T) {
 }
 
 func BenchmarkStringAlpha(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringAlphaTestCases {
-			_ = StringAlpha().Validate(tc.in)
+	for _, tc := range stringAlphaTestCases {
+		rule := StringAlpha()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1576,9 +1606,10 @@ func TestStringAlphanumeric(t *testing.T) {
 }
 
 func BenchmarkStringAlphanumeric(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringAlphanumericTestCases {
-			_ = StringAlphanumeric().Validate(tc.in)
+	for _, tc := range stringAlphanumericTestCases {
+		rule := StringAlphanumeric()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1618,9 +1649,10 @@ func TestStringAlphaUnicode(t *testing.T) {
 }
 
 func BenchmarkStringAlphaUnicode(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringAlphaUnicodeTestCases {
-			_ = StringAlphaUnicode().Validate(tc.in)
+	for _, tc := range stringAlphaUnicodeTestCases {
+		rule := StringAlphaUnicode()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }
@@ -1665,9 +1697,10 @@ func TestStringAlphanumericUnicode(t *testing.T) {
 }
 
 func BenchmarkStringAlphanumericUnicode(b *testing.B) {
-	for range b.N {
-		for _, tc := range stringAlphanumericUnicodeTestCases {
-			_ = StringAlphanumericUnicode().Validate(tc.in)
+	for _, tc := range stringAlphanumericUnicodeTestCases {
+		rule := StringAlphanumericUnicode()
+		for range b.N {
+			_ = rule.Validate(tc.in)
 		}
 	}
 }

--- a/pkg/rules/unique_test.go
+++ b/pkg/rules/unique_test.go
@@ -85,9 +85,10 @@ func TestSliceUnique(t *testing.T) {
 }
 
 func BenchmarkSliceUnique(b *testing.B) {
-	for range b.N {
-		for _, tc := range sliceUniqueTestCases {
-			_ = SliceUnique(tc.hashFunc, tc.constraints...).Validate(tc.slice)
+	for _, tc := range sliceUniqueTestCases {
+		rule := SliceUnique(tc.hashFunc, tc.constraints...)
+		for range b.N {
+			_ = rule.Validate(tc.slice)
 		}
 	}
 }

--- a/pkg/rules/url_test.go
+++ b/pkg/rules/url_test.go
@@ -76,9 +76,10 @@ func BenchmarkURL(b *testing.B) {
 	}
 	b.ResetTimer()
 
-	for range b.N {
-		for _, u := range parsedURLs {
-			_ = URL().Validate(u)
+	for _, u := range parsedURLs {
+		for range b.N {
+			rule := URL()
+			_ = rule.Validate(u)
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

Currently benchmarks are run in a way that is not very realistic, i.e. the rule is initialized in every run.
Instead, what we should do is initialize the rule once and run benchmarks on the initalized rule.

In the future, If we want to benchmark rule initalization, we should do that in a separate benchmark.

## Summary

Instead of:

```go
for range b.N {
	for _, tc := range sliceUniqueTestCases {
		_ = SliceUnique(tc.hashFunc, tc.constraints...).Validate(tc.slice)
	}
}
```

we now run:

```go
for _, tc := range sliceUniqueTestCases {
	rule := SliceUnique(tc.hashFunc, tc.constraints...)
	for range b.N {
		_ = rule.Validate(tc.slice)
	}
}
```