### PR TITLE
feat: Add templating to all the builtin rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ func Example_basicUsage() {
 	// Output:
 	// Validation for John has failed for the following properties:
 	//   - 'name' with value 'John':
-	//     - must be one of [Jake, George]
+	//     - must be one of: Jake, George
 	//   - 'students' with value '[{"index":"918230014"},{"index":"9182300123"},{"index":"918230014"}]':
 	//     - length must be less than or equal to 2
 	//     - elements are not unique, 1st and 3rd elements collide

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,50 +2,50 @@
   "lockfile_version": "1",
   "packages": {
     "go@1.22": {
-      "last_modified": "2025-01-19T08:16:51Z",
-      "resolved": "github:NixOS/nixpkgs/50165c4f7eb48ce82bd063e1fb8047a0f515f8ce#go_1_22",
+      "last_modified": "2025-02-05T05:41:33Z",
+      "resolved": "github:NixOS/nixpkgs/5b2753b0356d1c951d7a3ef1d086ba5a71fff43c#go_1_22",
       "source": "devbox-search",
-      "version": "1.22.11",
+      "version": "1.22.12",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/n2z6im8iiv9lr59yjfsv44k0fxz7l7j8-go-1.22.11",
+              "path": "/nix/store/ff0qyzh1faxmbzkpzw82x29ajs19il8i-go-1.22.12",
               "default": true
             }
           ],
-          "store_path": "/nix/store/n2z6im8iiv9lr59yjfsv44k0fxz7l7j8-go-1.22.11"
+          "store_path": "/nix/store/ff0qyzh1faxmbzkpzw82x29ajs19il8i-go-1.22.12"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/6d2jvkjgl8kqyf060qc91028h9cn31ic-go-1.22.11",
+              "path": "/nix/store/prg2xh9rpfw1qslxqyvqxz8c7c0g3sb5-go-1.22.12",
               "default": true
             }
           ],
-          "store_path": "/nix/store/6d2jvkjgl8kqyf060qc91028h9cn31ic-go-1.22.11"
+          "store_path": "/nix/store/prg2xh9rpfw1qslxqyvqxz8c7c0g3sb5-go-1.22.12"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/w8zix38rx053wrvd1vabnha98b16b6ad-go-1.22.11",
+              "path": "/nix/store/lzqrskhfcq6hcsx11brn3q88yzkyj0sz-go-1.22.12",
               "default": true
             }
           ],
-          "store_path": "/nix/store/w8zix38rx053wrvd1vabnha98b16b6ad-go-1.22.11"
+          "store_path": "/nix/store/lzqrskhfcq6hcsx11brn3q88yzkyj0sz-go-1.22.12"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/mycvbw9hbsd122qs1h4dapypkfnmslhw-go-1.22.11",
+              "path": "/nix/store/rm130rzpw39nvb5ig529sa0zl0qlygkl-go-1.22.12",
               "default": true
             }
           ],
-          "store_path": "/nix/store/mycvbw9hbsd122qs1h4dapypkfnmslhw-go-1.22.11"
+          "store_path": "/nix/store/rm130rzpw39nvb5ig529sa0zl0qlygkl-go-1.22.12"
         }
       }
     },
@@ -357,11 +357,11 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/gvmr94wic9z2nq310cf85nr4z39p0y7m-yarn-1.22.22",
+              "path": "/nix/store/r2agp60y6ww9dxglbvdsh4jir722vk9y-yarn-1.22.22",
               "default": true
             }
           ],
-          "store_path": "/nix/store/gvmr94wic9z2nq310cf85nr4z39p0y7m-yarn-1.22.22"
+          "store_path": "/nix/store/r2agp60y6ww9dxglbvdsh4jir722vk9y-yarn-1.22.22"
         },
         "x86_64-darwin": {
           "outputs": [

--- a/internal/examples/readme_intro_example_test.go
+++ b/internal/examples/readme_intro_example_test.go
@@ -93,7 +93,7 @@ func Example_basicUsage() {
 	// Output:
 	// Validation for John has failed for the following properties:
 	//   - 'name' with value 'John':
-	//     - must be one of [Jake, George]
+	//     - must be one of: Jake, George
 	//   - 'students' with value '[{"index":"918230014"},{"index":"9182300123"},{"index":"918230014"}]':
 	//     - length must be less than or equal to 2
 	//     - elements are not unique, 1st and 3rd elements collide

--- a/internal/messagetemplates/cache_test.go
+++ b/internal/messagetemplates/cache_test.go
@@ -16,12 +16,12 @@ func TestGet(t *testing.T) {
 	}
 
 	assert.Len(t, messageTemplatesCache.tmpl, 0)
-	tpl := Get(StringLengthTemplate)
+	tpl := Get(LengthTemplate)
 	actual := mustExecuteTemplate(t, tpl, vars)
 	assert.Equal(t, expected, actual)
 
 	assert.Len(t, messageTemplatesCache.tmpl, 1)
-	tpl = Get(StringLengthTemplate)
+	tpl = Get(LengthTemplate)
 	actual = mustExecuteTemplate(t, tpl, vars)
 	assert.Equal(t, expected, actual)
 }

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -7,12 +7,24 @@ const (
 	LengthTemplate templateKey = iota + 1
 	MinLengthTemplate
 	MaxLengthTemplate
+	EQTemplate
+	NEQTemplate
+	GTTemplate
+	GTETemplate
+	LTTemplate
+	LTETemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
 	LengthTemplate:    "length must be between {{ .MinLength }} and {{ .MaxLength }}",
-	MinLengthTemplate: "length must be greater than or equal to {{ .MinLength }}",
-	MaxLengthTemplate: "length must be less than or equal to {{ .MaxLength }}",
+	MinLengthTemplate: "length must be greater than or equal to {{ .ComparedValue }}",
+	MaxLengthTemplate: "length must be less than or equal to '{{ .ComparedValue }}'",
+	EQTemplate:        "should be equal to '{{ .ComparedValue }}'",
+	NEQTemplate:       "should be not equal to '{{ .ComparedValue }}'",
+	GTTemplate:        "should be greater than '{{ .ComparedValue }}'",
+	GTETemplate:       "should be greater than or equal to '{{ .ComparedValue }}'",
+	LTTemplate:        "should be less than '{{ .ComparedValue }}'",
+	LTETemplate:       "should be less than or equal to '{{ .ComparedValue }}'",
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -4,11 +4,15 @@ package messagetemplates
 type templateKey int
 
 const (
-	StringLengthTemplate templateKey = iota + 1
+	LengthTemplate templateKey = iota + 1
+	MinLengthTemplate
+	MaxLengthTemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
-	StringLengthTemplate: "length must be between {{ .MinLength }} and {{ .MaxLength }}",
+	LengthTemplate:    "length must be between {{ .MinLength }} and {{ .MaxLength }}",
+	MinLengthTemplate: "length must be greater than or equal to {{ .MinLength }}",
+	MaxLengthTemplate: "length must be less than or equal to {{ .MaxLength }}",
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -52,6 +52,7 @@ const (
 	SliceUniqueTemplate
 )
 
+// nolint: lll
 var rawMessageTemplates = map[templateKey]string{
 	LengthTemplate:            "length must be between {{ .MinLength }} and {{ .MaxLength }}",
 	MinLengthTemplate:         "length must be greater than or equal to {{ .ComparisonValue }}",
@@ -65,7 +66,7 @@ var rawMessageTemplates = map[templateKey]string{
 	EqualPropertiesTemplate:   `all of [{{ joinStringSlice .ComparisonValue "" }}] properties must be equal, but '{{ .Custom.FirstNotEqual }}' is not equal to '{{ .Custom.SecondNotEqual }}'`,
 	DurationPrecisionTemplate: "duration must be defined with {{ .ComparisonValue }} precision",
 	ForbiddenTemplate:         "property is forbidden",
-	OneOfTemplate:             `must be one of [{{ joinStringSlice .ComparisonValue "" }}]`,
+	OneOfTemplate:             `must be one of: {{ joinStringSlice .ComparisonValue "" }}`,
 	OneOfPropertiesTemplate:   `one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided`,
 	MutuallyExclusiveTemplate: `
 {{- if .Custom.NoProperties -}}

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -13,18 +13,20 @@ const (
 	GTETemplate
 	LTTemplate
 	LTETemplate
+	DurationPrecisionTemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
-	LengthTemplate:    "length must be between {{ .MinLength }} and {{ .MaxLength }}",
-	MinLengthTemplate: "length must be greater than or equal to {{ .ComparedValue }}",
-	MaxLengthTemplate: "length must be less than or equal to '{{ .ComparedValue }}'",
-	EQTemplate:        "should be equal to '{{ .ComparedValue }}'",
-	NEQTemplate:       "should be not equal to '{{ .ComparedValue }}'",
-	GTTemplate:        "should be greater than '{{ .ComparedValue }}'",
-	GTETemplate:       "should be greater than or equal to '{{ .ComparedValue }}'",
-	LTTemplate:        "should be less than '{{ .ComparedValue }}'",
-	LTETemplate:       "should be less than or equal to '{{ .ComparedValue }}'",
+	LengthTemplate:            "length must be between {{ .MinLength }} and {{ .MaxLength }}",
+	MinLengthTemplate:         "length must be greater than or equal to {{ .ComparisonValue }}",
+	MaxLengthTemplate:         "length must be less than or equal to '{{ .ComparisonValue }}'",
+	EQTemplate:                "should be equal to '{{ .ComparisonValue }}'",
+	NEQTemplate:               "should be not equal to '{{ .ComparisonValue }}'",
+	GTTemplate:                "should be greater than '{{ .ComparisonValue }}'",
+	GTETemplate:               "should be greater than or equal to '{{ .ComparisonValue }}'",
+	LTTemplate:                "should be less than '{{ .ComparisonValue }}'",
+	LTETemplate:               "should be less than or equal to '{{ .ComparisonValue }}'",
+	DurationPrecisionTemplate: "duration must be defined with {{ .ComparisonValue }} precision",
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -14,6 +14,7 @@ const (
 	LTTemplate
 	LTETemplate
 	DurationPrecisionTemplate
+	ForbiddenTemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
@@ -27,6 +28,7 @@ var rawMessageTemplates = map[templateKey]string{
 	LTTemplate:                "should be less than '{{ .ComparisonValue }}'",
 	LTETemplate:               "should be less than or equal to '{{ .ComparisonValue }}'",
 	DurationPrecisionTemplate: "duration must be defined with {{ .ComparisonValue }} precision",
+	ForbiddenTemplate:         "property is forbidden",
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -49,12 +49,13 @@ const (
 	StringDateTimeTemplate
 	StringTimeZoneTemplate
 	URLTemplate
+	SliceUniqueTemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
 	LengthTemplate:            "length must be between {{ .MinLength }} and {{ .MaxLength }}",
 	MinLengthTemplate:         "length must be greater than or equal to {{ .ComparisonValue }}",
-	MaxLengthTemplate:         "length must be less than or equal to '{{ .ComparisonValue }}'",
+	MaxLengthTemplate:         "length must be less than or equal to {{ .ComparisonValue }}",
 	EQTemplate:                "should be equal to '{{ .ComparisonValue }}'",
 	NEQTemplate:               "should be not equal to '{{ .ComparisonValue }}'",
 	GTTemplate:                "should be greater than '{{ .ComparisonValue }}'",
@@ -127,7 +128,9 @@ string must be a valid git reference
 	StringCrontabTemplate:             "string must be a valid cron schedule expression",
 	StringDateTimeTemplate:            "string must be a valid date and time in '{{ .ComparisonValue }}' format{{- if .Error }}: {{ .Error }}{{- end }}",
 	StringTimeZoneTemplate:            "string must be a valid IANA Time Zone Database code{{- if .Error }}: {{ .Error }}{{- end }}",
-	URLTemplate:                       "{{ .Error }}",
+	SliceUniqueTemplate: `elements are not unique, {{ .Custom.FirstOrdinal }} and {{ .Custom.SecondOrdinal }} elements collide
+{{- if gt (len .Custom.Constraints) 0 }} based on constraints: {{ joinStringSlice .Custom.Constraints "" }}{{- end }}`,
+	URLTemplate: "{{ .Error }}",
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -15,12 +15,40 @@ const (
 	GTETemplate
 	LTTemplate
 	LTETemplate
+	EqualPropertiesTemplate
 	DurationPrecisionTemplate
 	ForbiddenTemplate
 	OneOfTemplate
 	OneOfPropertiesTemplate
 	MutuallyExclusiveTemplate
 	RequiredTemplate
+	StringNonEmptyTemplate
+	StringMatchRegexpTemplate
+	StringDenyRegexpTemplate
+	StringEmailTemplate
+	StringMACTemplate
+	StringIPTemplate
+	StringIPv4Template
+	StringIPv6Template
+	StringCIDRTemplate
+	StringCIDRv4Template
+	StringCIDRv6Template
+	StringJSONTemplate
+	StringContainsTemplate
+	StringExcludesTemplate
+	StringStartsWithTemplate
+	StringEndsWithTemplate
+	StringTitleTemplate
+	StringGitRefTemplate
+	StringFileSystemPathTemplate
+	StringFilePathTemplate
+	StringDirPathTemplate
+	StringMatchFileSystemPathTemplate
+	StringRegexpTemplate
+	StringCrontabTemplate
+	StringDateTimeTemplate
+	StringTimeZoneTemplate
+	URLTemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
@@ -33,12 +61,73 @@ var rawMessageTemplates = map[templateKey]string{
 	GTETemplate:               "should be greater than or equal to '{{ .ComparisonValue }}'",
 	LTTemplate:                "should be less than '{{ .ComparisonValue }}'",
 	LTETemplate:               "should be less than or equal to '{{ .ComparisonValue }}'",
+	EqualPropertiesTemplate:   `all of [{{ joinStringSlice .ComparisonValue "" }}] properties must be equal, but '{{ .Custom.FirstNotEqual }}' is not equal to '{{ .Custom.SecondNotEqual }}'`,
 	DurationPrecisionTemplate: "duration must be defined with {{ .ComparisonValue }} precision",
 	ForbiddenTemplate:         "property is forbidden",
 	OneOfTemplate:             `must be one of [{{ joinStringSlice .ComparisonValue "" }}]`,
 	OneOfPropertiesTemplate:   `one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided`,
-	MutuallyExclusiveTemplate: `{{- if .Custom.NoProperties }}one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided{{- else }}[{{ joinStringSlice .ComparisonValue "" }}] properties are mutually exclusive, provide only one of them{{- end }}`,
+	MutuallyExclusiveTemplate: `
+{{- if .Custom.NoProperties -}}
+one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided
+{{- else -}}
+[{{ joinStringSlice .ComparisonValue "" }}] properties are mutually exclusive, provide only one of them
+{{- end }}`,
 	RequiredTemplate:          internal.RequiredErrorMessage,
+	StringNonEmptyTemplate:    "string cannot be empty",
+	StringMatchRegexpTemplate: "string must match regular expression: '{{ .ComparisonValue }}'",
+	StringDenyRegexpTemplate:  "string must not match regular expression: '{{ .ComparisonValue }}'",
+	StringEmailTemplate:       "string must be a valid email address: {{ .Error }}",
+	StringMACTemplate:         "string must be a valid MAC address",
+	StringIPTemplate:          "string must be a valid IP address",
+	StringIPv4Template:        "string must be a valid IPv4 address",
+	StringIPv6Template:        "string must be a valid IPv6 address",
+	StringCIDRTemplate:        "string must be a valid CIDR notation IP address",
+	StringCIDRv4Template:      "string must be a valid CIDR notation IPv4 address",
+	StringCIDRv6Template:      "string must be a valid CIDR notation IPv6 address",
+	StringJSONTemplate:        "string must be a valid JSON",
+	StringContainsTemplate:    `string must contain the following substrings: {{ joinStringSlice .ComparisonValue "'" }}`,
+	StringExcludesTemplate:    `string must not contain any of the following substrings: {{ joinStringSlice .ComparisonValue "'" }}`,
+	StringStartsWithTemplate: `
+{{- if eq (len .ComparisonValue) 1 -}}
+string must start with '{{ index .ComparisonValue 0 }}' prefix
+{{- else -}}
+string must start with one of the following prefixes: {{ joinStringSlice .ComparisonValue "'" }}
+{{- end }}
+`,
+	StringEndsWithTemplate: `
+{{- if eq (len .ComparisonValue) 1 -}}
+string must end with '{{ index .ComparisonValue 0 }}' suffix
+{{- else -}}
+string must end with one of the following suffixes: {{ joinStringSlice .ComparisonValue "'" }}
+{{- end }}
+`,
+	StringTitleTemplate: "each word in a string must start with a capital letter",
+	StringGitRefTemplate: `
+{{- if eq .Custom.GitRefEmpty true -}}
+git reference cannot be empty
+{{- else if eq .Custom.GitRefEndsWithDot true -}}
+git reference must not end with a '.'
+{{- else if eq .Custom.GitRefAtLeastOneSlash true -}}
+git reference must contain at least one '/'
+{{- else if eq .Custom.GitRefEmptyPart true -}}
+git reference must not have empty parts
+{{- else if eq .Custom.GitRefStartsWithDash true -}}
+git branch and tag references must not start with '-'
+{{- else if eq .Custom.GitRefForbiddenChars true -}}
+git reference contains forbidden characters
+{{- else -}}
+string must be a valid git reference
+{{- end }}
+`,
+	StringFileSystemPathTemplate:      "string must be an existing file system path{{- if .Error }}: {{ .Error }}{{- end }}",
+	StringFilePathTemplate:            "string must be a file system path to an existing file{{- if .Error }}: {{ .Error }}{{- end }}",
+	StringDirPathTemplate:             "string must be a file system path to an existing directory{{- if .Error }}: {{ .Error }}{{- end }}",
+	StringMatchFileSystemPathTemplate: "string must match file path pattern: '{{ .ComparisonValue }}'{{- if .Error }}: {{ .Error }}{{- end }}",
+	StringRegexpTemplate:              "string must be a valid regular expression{{- if .Error }}: {{ .Error }}{{- end }}",
+	StringCrontabTemplate:             "string must be a valid cron schedule expression",
+	StringDateTimeTemplate:            "string must be a valid date and time in '{{ .ComparisonValue }}' format{{- if .Error }}: {{ .Error }}{{- end }}",
+	StringTimeZoneTemplate:            "string must be a valid IANA Time Zone Database code{{- if .Error }}: {{ .Error }}{{- end }}",
+	URLTemplate:                       "{{ .Error }}",
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -1,5 +1,7 @@
 package messagetemplates
 
+import "github.com/nobl9/govy/internal"
+
 // templateKey is a key that uniquely identifies a message template.
 type templateKey int
 
@@ -18,6 +20,7 @@ const (
 	OneOfTemplate
 	OneOfPropertiesTemplate
 	MutuallyExclusiveTemplate
+	RequiredTemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
@@ -35,6 +38,7 @@ var rawMessageTemplates = map[templateKey]string{
 	OneOfTemplate:             `must be one of [{{ joinStringSlice .ComparisonValue "" }}]`,
 	OneOfPropertiesTemplate:   `one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided`,
 	MutuallyExclusiveTemplate: `{{- if .Custom.NoProperties }}one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided{{- else }}[{{ joinStringSlice .ComparisonValue "" }}] properties are mutually exclusive, provide only one of them{{- end }}`,
+	RequiredTemplate:          internal.RequiredErrorMessage,
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -15,6 +15,9 @@ const (
 	LTETemplate
 	DurationPrecisionTemplate
 	ForbiddenTemplate
+	OneOfTemplate
+	OneOfPropertiesTemplate
+	MutuallyExclusiveTemplate
 )
 
 var rawMessageTemplates = map[templateKey]string{
@@ -29,6 +32,9 @@ var rawMessageTemplates = map[templateKey]string{
 	LTETemplate:               "should be less than or equal to '{{ .ComparisonValue }}'",
 	DurationPrecisionTemplate: "duration must be defined with {{ .ComparisonValue }} precision",
 	ForbiddenTemplate:         "property is forbidden",
+	OneOfTemplate:             `must be one of [{{ joinStringSlice .ComparisonValue "" }}]`,
+	OneOfPropertiesTemplate:   `one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided`,
+	MutuallyExclusiveTemplate: `{{- if .Custom.NoProperties }}one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided{{- else }}[{{ joinStringSlice .ComparisonValue "" }}] properties are mutually exclusive, provide only one of them{{- end }}`,
 }
 
 // commonTemplateSuffix is a suffix that is added to all message templates.

--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -285,9 +285,10 @@ type TemplateVars struct {
 	Examples      []string
 	Details       string
 	// Builtin variables which are available only for selected rules.
-	Error     string
-	MinLength int
-	MaxLength int
+	Error         string
+	MinLength     int
+	MaxLength     int
+	ComparedValue any
 	// Custom variables provided by the user, this can be anything,
 	// e.g. map[string]any or a struct.
 	Custom any

--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -284,15 +284,20 @@ type TemplateVars struct {
 	PropertyValue any
 	Examples      []string
 	Details       string
-	// Builtin variables which are available only for selected rules.
-	Error     string
-	MinLength int
-	MaxLength int
+
+	// Builtin, widely used variables which are available only for selected rules.
+
+	// Error is the dynamic error returned by underlying functions evaluated by the rule,
+	// for instance an error returned by [net/url.Parse].
+	Error string
 	// ComparisonValue is the value defined most commonly during rule creation
 	// to which runtime values are compared.
 	ComparisonValue any
-	// Custom variables provided by the user, this can be anything,
-	// e.g. map[string]any or a struct.
+	MinLength       int
+	MaxLength       int
+
+	// Custom variables either provided by the user or case specific,
+	// this can be anything, for instance map[string]any or a struct.
 	Custom any
 }
 

--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -285,10 +285,12 @@ type TemplateVars struct {
 	Examples      []string
 	Details       string
 	// Builtin variables which are available only for selected rules.
-	Error         string
-	MinLength     int
-	MaxLength     int
-	ComparedValue any
+	Error     string
+	MinLength int
+	MaxLength int
+	// ComparisonValue is the value defined most commonly during rule creation
+	// to which runtime values are compared.
+	ComparisonValue any
 	// Custom variables provided by the user, this can be anything,
 	// e.g. map[string]any or a struct.
 	Custom any

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -1552,7 +1552,7 @@ func ExampleValidator() {
 	// Output:
 	// Validation for John has failed for the following properties:
 	//   - 'name' with value 'John':
-	//     - must be one of [Jake, George]
+	//     - must be one of: Jake, George
 	//   - 'students' with value '[{"index":"918230014"},{"index":"9182300123"},{"index":"918230014"}]':
 	//     - length must be less than or equal to 2
 	//     - elements are not unique, 1st and 3rd elements collide

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -74,8 +74,11 @@ func (r Rule[T]) Validate(v T) error {
 			}
 			return ev
 		case RuleErrorTemplate:
+			if r.message != "" {
+				break
+			}
 			if r.messageTemplate == nil {
-				panic("message template is not set")
+				panic(fmt.Sprintf("rule returned %T error but message template is not set", ev))
 			}
 			ev.vars.PropertyValue = v
 			ev.vars.Details = r.details
@@ -89,16 +92,15 @@ func (r Rule[T]) Validate(v T) error {
 				Code:        r.errorCode,
 				Description: r.description,
 			}
-		default:
-			msg := ev.Error()
-			if len(r.message) > 0 {
-				msg = r.message
-			}
-			return &RuleError{
-				Message:     createErrorMessage(msg, r.details, r.examples),
-				Code:        r.errorCode,
-				Description: r.description,
-			}
+		}
+		msg := err.Error()
+		if len(r.message) > 0 {
+			msg = r.message
+		}
+		return &RuleError{
+			Message:     createErrorMessage(msg, r.details, r.examples),
+			Code:        r.errorCode,
+			Description: r.description,
 		}
 	}
 	return nil

--- a/pkg/govytest/example_test.go
+++ b/pkg/govytest/example_test.go
@@ -65,7 +65,7 @@ func ExampleAssertNoError() {
 	//       "propertyValue": "John",
 	//       "errors": [
 	//         {
-	//           "error": "must be one of [Jake, George]",
+	//           "error": "must be one of: Jake, George",
 	//           "code": "one_of",
 	//           "description": "must be one of: Jake, George"
 	//         }
@@ -150,7 +150,7 @@ func ExampleAssertError() {
 	//     "propertyValue": "John",
 	//     "errors": [
 	//       {
-	//         "error": "must be one of [Jake, George]",
+	//         "error": "must be one of: Jake, George",
 	//         "code": "one_of",
 	//         "description": "must be one of: Jake, George"
 	//       }
@@ -233,7 +233,7 @@ func ExampleAssertErrorContains() {
 	//     "propertyValue": "John",
 	//     "errors": [
 	//       {
-	//         "error": "must be one of [Jake, George]",
+	//         "error": "must be one of: Jake, George",
 	//         "code": "one_of",
 	//         "description": "must be one of: Jake, George"
 	//       }

--- a/pkg/rules/comparable.go
+++ b/pkg/rules/comparable.go
@@ -19,8 +19,8 @@ func EQ[T comparable](compared T) govy.Rule[T] {
 	return govy.NewRule(func(v T) error {
 		if v != compared {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: compared,
+				PropertyValue:   v,
+				ComparisonValue: compared,
 			})
 		}
 		return nil
@@ -28,7 +28,7 @@ func EQ[T comparable](compared T) govy.Rule[T] {
 		WithErrorCode(ErrorCodeEqualTo).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: compared,
+			ComparisonValue: compared,
 		}))
 }
 
@@ -39,8 +39,8 @@ func NEQ[T comparable](compared T) govy.Rule[T] {
 	return govy.NewRule(func(v T) error {
 		if v == compared {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: compared,
+				PropertyValue:   v,
+				ComparisonValue: compared,
 			})
 		}
 		return nil
@@ -48,7 +48,7 @@ func NEQ[T comparable](compared T) govy.Rule[T] {
 		WithErrorCode(ErrorCodeNotEqualTo).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: compared,
+			ComparisonValue: compared,
 		}))
 }
 
@@ -59,8 +59,8 @@ func GT[T constraints.Ordered](compared T) govy.Rule[T] {
 	return govy.NewRule(func(v T) error {
 		if v <= compared {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: compared,
+				PropertyValue:   v,
+				ComparisonValue: compared,
 			})
 		}
 		return nil
@@ -68,7 +68,7 @@ func GT[T constraints.Ordered](compared T) govy.Rule[T] {
 		WithErrorCode(ErrorCodeGreaterThan).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: compared,
+			ComparisonValue: compared,
 		}))
 }
 
@@ -79,8 +79,8 @@ func GTE[T constraints.Ordered](compared T) govy.Rule[T] {
 	return govy.NewRule(func(v T) error {
 		if v < compared {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: compared,
+				PropertyValue:   v,
+				ComparisonValue: compared,
 			})
 		}
 		return nil
@@ -88,7 +88,7 @@ func GTE[T constraints.Ordered](compared T) govy.Rule[T] {
 		WithErrorCode(ErrorCodeGreaterThanOrEqualTo).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: compared,
+			ComparisonValue: compared,
 		}))
 }
 
@@ -99,8 +99,8 @@ func LT[T constraints.Ordered](compared T) govy.Rule[T] {
 	return govy.NewRule(func(v T) error {
 		if v >= compared {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: compared,
+				PropertyValue:   v,
+				ComparisonValue: compared,
 			})
 		}
 		return nil
@@ -108,7 +108,7 @@ func LT[T constraints.Ordered](compared T) govy.Rule[T] {
 		WithErrorCode(ErrorCodeLessThan).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: compared,
+			ComparisonValue: compared,
 		}))
 }
 
@@ -119,8 +119,8 @@ func LTE[T constraints.Ordered](compared T) govy.Rule[T] {
 	return govy.NewRule(func(v T) error {
 		if v > compared {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: compared,
+				PropertyValue:   v,
+				ComparisonValue: compared,
 			})
 		}
 		return nil
@@ -128,7 +128,7 @@ func LTE[T constraints.Ordered](compared T) govy.Rule[T] {
 		WithErrorCode(ErrorCodeLessThanOrEqualTo).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: compared,
+			ComparisonValue: compared,
 		}))
 }
 

--- a/pkg/rules/duration.go
+++ b/pkg/rules/duration.go
@@ -1,22 +1,28 @@
 package rules
 
 import (
-	"errors"
-	"fmt"
 	"time"
 
+	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
 )
 
 // DurationPrecision ensures the duration is defined with the specified precision.
 func DurationPrecision(precision time.Duration) govy.Rule[time.Duration] {
-	msg := fmt.Sprintf("duration must be defined with %s precision", precision)
+	tpl := messagetemplates.Get(messagetemplates.DurationPrecisionTemplate)
+
 	return govy.NewRule(func(v time.Duration) error {
 		if v.Nanoseconds()%int64(precision) != 0 {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   v,
+				ComparisonValue: precision,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeDurationPrecision).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			PropertyValue: precision,
+		}))
 }

--- a/pkg/rules/forbidden.go
+++ b/pkg/rules/forbidden.go
@@ -1,21 +1,24 @@
 package rules
 
 import (
-	"errors"
-
 	"github.com/nobl9/govy/internal"
+	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
 )
 
 // Forbidden ensures the property's value is its type's zero value, i.e. it's empty.
 func Forbidden[T any]() govy.Rule[T] {
-	msg := "property is forbidden"
+	tpl := messagetemplates.Get(messagetemplates.ForbiddenTemplate)
+
 	return govy.NewRule(func(v T) error {
 		if internal.IsEmpty(v) {
 			return nil
 		}
-		return errors.New(msg)
+		return govy.NewRuleErrorTemplate(govy.TemplateVars{
+			PropertyValue: v,
+		})
 	}).
 		WithErrorCode(ErrorCodeForbidden).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }

--- a/pkg/rules/length.go
+++ b/pkg/rules/length.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"errors"
 	"fmt"
 	"unicode/utf8"
 
@@ -16,7 +15,7 @@ import (
 //   - [govy.TemplateVars.MaxLength].
 func StringLength(minLen, maxLen int) govy.Rule[string] {
 	enforceMinMaxLength(minLen, maxLen)
-	tpl := messagetemplates.Get(messagetemplates.StringLengthTemplate)
+	tpl := messagetemplates.Get(messagetemplates.LengthTemplate)
 
 	return govy.NewRule(func(v string) error {
 		length := utf8.RuneCountInString(v)
@@ -39,116 +38,176 @@ func StringLength(minLen, maxLen int) govy.Rule[string] {
 
 // StringMinLength ensures the string's length is greater than or equal to the limit.
 func StringMinLength(limit int) govy.Rule[string] {
-	msg := fmt.Sprintf("length must be %s %d", cmpGreaterThanOrEqual, limit)
+	tpl := messagetemplates.Get(messagetemplates.MinLengthTemplate)
+
 	return govy.NewRule(func(v string) error {
 		length := utf8.RuneCountInString(v)
 		if length < limit {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MinLength:     limit,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringMinLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MinLength: limit,
+		}))
 }
 
 // StringMaxLength ensures the string's length is less than or equal to the limit.
 func StringMaxLength(limit int) govy.Rule[string] {
-	msg := fmt.Sprintf("length must be %s %d", cmpLessThanOrEqual, limit)
+	tpl := messagetemplates.Get(messagetemplates.MaxLengthTemplate)
+
 	return govy.NewRule(func(v string) error {
 		length := utf8.RuneCountInString(v)
 		if length > limit {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MaxLength:     limit,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringMaxLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MaxLength: limit,
+		}))
 }
 
 // SliceLength ensures the slice's length is between min and max (closed interval).
 func SliceLength[S ~[]E, E any](minLen, maxLen int) govy.Rule[S] {
 	enforceMinMaxLength(minLen, maxLen)
-	msg := fmt.Sprintf("length must be between %d and %d", minLen, maxLen)
+	tpl := messagetemplates.Get(messagetemplates.LengthTemplate)
+
 	return govy.NewRule(func(v S) error {
 		length := len(v)
 		if length < minLen || length > maxLen {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MinLength:     minLen,
+				MaxLength:     maxLen,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeSliceLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MinLength: minLen,
+			MaxLength: maxLen,
+		}))
 }
 
 // SliceMinLength ensures the slice's length is greater than or equal to the limit.
 func SliceMinLength[S ~[]E, E any](limit int) govy.Rule[S] {
-	msg := fmt.Sprintf("length must be %s %d", cmpGreaterThanOrEqual, limit)
+	tpl := messagetemplates.Get(messagetemplates.MinLengthTemplate)
+
 	return govy.NewRule(func(v S) error {
 		length := len(v)
 		if length < limit {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MinLength:     limit,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeSliceMinLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MinLength: limit,
+		}))
 }
 
 // SliceMaxLength ensures the slice's length is less than or equal to the limit.
 func SliceMaxLength[S ~[]E, E any](limit int) govy.Rule[S] {
-	msg := fmt.Sprintf("length must be %s %d", cmpLessThanOrEqual, limit)
+	tpl := messagetemplates.Get(messagetemplates.MaxLengthTemplate)
+
 	return govy.NewRule(func(v S) error {
 		length := len(v)
 		if length > limit {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MaxLength:     limit,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeSliceMaxLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MaxLength: limit,
+		}))
 }
 
 // MapLength ensures the map's length is between min and max (closed interval).
 func MapLength[M ~map[K]V, K comparable, V any](minLen, maxLen int) govy.Rule[M] {
 	enforceMinMaxLength(minLen, maxLen)
-	msg := fmt.Sprintf("length must be between %d and %d", minLen, maxLen)
+	tpl := messagetemplates.Get(messagetemplates.LengthTemplate)
+
 	return govy.NewRule(func(v M) error {
 		length := len(v)
 		if length < minLen || length > maxLen {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MinLength:     minLen,
+				MaxLength:     maxLen,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeMapLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MinLength: minLen,
+			MaxLength: maxLen,
+		}))
 }
 
 // MapMinLength ensures the map's length is greater than or equal to the limit.
 func MapMinLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
-	msg := fmt.Sprintf("length must be %s %d", cmpGreaterThanOrEqual, limit)
+	tpl := messagetemplates.Get(messagetemplates.MinLengthTemplate)
+
 	return govy.NewRule(func(v M) error {
 		length := len(v)
 		if length < limit {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MinLength:     limit,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeMapMinLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MinLength: limit,
+		}))
 }
 
 // MapMaxLength ensures the map's length is less than or equal to the limit.
 func MapMaxLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
-	msg := fmt.Sprintf("length must be %s %d", cmpLessThanOrEqual, limit)
+	tpl := messagetemplates.Get(messagetemplates.MaxLengthTemplate)
+
 	return govy.NewRule(func(v M) error {
 		length := len(v)
 		if length > limit {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+				MaxLength:     limit,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeMapMaxLength).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			MaxLength: limit,
+		}))
 }
 
 func enforceMinMaxLength(minLen, maxLen int) {

--- a/pkg/rules/length.go
+++ b/pkg/rules/length.go
@@ -44,8 +44,8 @@ func StringMinLength(limit int) govy.Rule[string] {
 		length := utf8.RuneCountInString(v)
 		if length < limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: limit,
+				PropertyValue:   v,
+				ComparisonValue: limit,
 			})
 		}
 		return nil
@@ -53,7 +53,7 @@ func StringMinLength(limit int) govy.Rule[string] {
 		WithErrorCode(ErrorCodeStringMinLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: limit,
+			ComparisonValue: limit,
 		}))
 }
 
@@ -65,8 +65,8 @@ func StringMaxLength(limit int) govy.Rule[string] {
 		length := utf8.RuneCountInString(v)
 		if length > limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: limit,
+				PropertyValue:   v,
+				ComparisonValue: limit,
 			})
 		}
 		return nil
@@ -74,7 +74,7 @@ func StringMaxLength(limit int) govy.Rule[string] {
 		WithErrorCode(ErrorCodeStringMaxLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: limit,
+			ComparisonValue: limit,
 		}))
 }
 
@@ -114,8 +114,8 @@ func SliceMinLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		length := len(v)
 		if length < limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: limit,
+				PropertyValue:   v,
+				ComparisonValue: limit,
 			})
 		}
 		return nil
@@ -123,7 +123,7 @@ func SliceMinLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		WithErrorCode(ErrorCodeSliceMinLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: limit,
+			ComparisonValue: limit,
 		}))
 }
 
@@ -135,8 +135,8 @@ func SliceMaxLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		length := len(v)
 		if length > limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: limit,
+				PropertyValue:   v,
+				ComparisonValue: limit,
 			})
 		}
 		return nil
@@ -144,7 +144,7 @@ func SliceMaxLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		WithErrorCode(ErrorCodeSliceMaxLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: limit,
+			ComparisonValue: limit,
 		}))
 }
 
@@ -184,8 +184,8 @@ func MapMinLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		length := len(v)
 		if length < limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: limit,
+				PropertyValue:   v,
+				ComparisonValue: limit,
 			})
 		}
 		return nil
@@ -193,7 +193,7 @@ func MapMinLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		WithErrorCode(ErrorCodeMapMinLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: limit,
+			ComparisonValue: limit,
 		}))
 }
 
@@ -205,8 +205,8 @@ func MapMaxLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		length := len(v)
 		if length > limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
-				PropertyValue: v,
-				ComparedValue: limit,
+				PropertyValue:   v,
+				ComparisonValue: limit,
 			})
 		}
 		return nil
@@ -214,7 +214,7 @@ func MapMaxLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		WithErrorCode(ErrorCodeMapMaxLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			ComparedValue: limit,
+			ComparisonValue: limit,
 		}))
 }
 

--- a/pkg/rules/length.go
+++ b/pkg/rules/length.go
@@ -11,8 +11,8 @@ import (
 // StringLength ensures the string's length is between min and max (closed interval).
 //
 // The following, additional template variables are supported:
-//   - [govy.TemplateVars.MinLength].
-//   - [govy.TemplateVars.MaxLength].
+//   - [govy.TemplateVars.MinLength]
+//   - [govy.TemplateVars.MaxLength]
 func StringLength(minLen, maxLen int) govy.Rule[string] {
 	enforceMinMaxLength(minLen, maxLen)
 	tpl := messagetemplates.Get(messagetemplates.LengthTemplate)
@@ -45,7 +45,7 @@ func StringMinLength(limit int) govy.Rule[string] {
 		if length < limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
 				PropertyValue: v,
-				MinLength:     limit,
+				ComparedValue: limit,
 			})
 		}
 		return nil
@@ -53,7 +53,7 @@ func StringMinLength(limit int) govy.Rule[string] {
 		WithErrorCode(ErrorCodeStringMinLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			MinLength: limit,
+			ComparedValue: limit,
 		}))
 }
 
@@ -66,7 +66,7 @@ func StringMaxLength(limit int) govy.Rule[string] {
 		if length > limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
 				PropertyValue: v,
-				MaxLength:     limit,
+				ComparedValue: limit,
 			})
 		}
 		return nil
@@ -74,11 +74,15 @@ func StringMaxLength(limit int) govy.Rule[string] {
 		WithErrorCode(ErrorCodeStringMaxLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			MaxLength: limit,
+			ComparedValue: limit,
 		}))
 }
 
 // SliceLength ensures the slice's length is between min and max (closed interval).
+//
+// The following, additional template variables are supported:
+//   - [govy.TemplateVars.MinLength]
+//   - [govy.TemplateVars.MaxLength]
 func SliceLength[S ~[]E, E any](minLen, maxLen int) govy.Rule[S] {
 	enforceMinMaxLength(minLen, maxLen)
 	tpl := messagetemplates.Get(messagetemplates.LengthTemplate)
@@ -111,7 +115,7 @@ func SliceMinLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		if length < limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
 				PropertyValue: v,
-				MinLength:     limit,
+				ComparedValue: limit,
 			})
 		}
 		return nil
@@ -119,7 +123,7 @@ func SliceMinLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		WithErrorCode(ErrorCodeSliceMinLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			MinLength: limit,
+			ComparedValue: limit,
 		}))
 }
 
@@ -132,7 +136,7 @@ func SliceMaxLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		if length > limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
 				PropertyValue: v,
-				MaxLength:     limit,
+				ComparedValue: limit,
 			})
 		}
 		return nil
@@ -140,11 +144,15 @@ func SliceMaxLength[S ~[]E, E any](limit int) govy.Rule[S] {
 		WithErrorCode(ErrorCodeSliceMaxLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			MaxLength: limit,
+			ComparedValue: limit,
 		}))
 }
 
 // MapLength ensures the map's length is between min and max (closed interval).
+//
+// The following, additional template variables are supported:
+//   - [govy.TemplateVars.MinLength]
+//   - [govy.TemplateVars.MaxLength]
 func MapLength[M ~map[K]V, K comparable, V any](minLen, maxLen int) govy.Rule[M] {
 	enforceMinMaxLength(minLen, maxLen)
 	tpl := messagetemplates.Get(messagetemplates.LengthTemplate)
@@ -177,7 +185,7 @@ func MapMinLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		if length < limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
 				PropertyValue: v,
-				MinLength:     limit,
+				ComparedValue: limit,
 			})
 		}
 		return nil
@@ -185,7 +193,7 @@ func MapMinLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		WithErrorCode(ErrorCodeMapMinLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			MinLength: limit,
+			ComparedValue: limit,
 		}))
 }
 
@@ -198,7 +206,7 @@ func MapMaxLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		if length > limit {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
 				PropertyValue: v,
-				MaxLength:     limit,
+				ComparedValue: limit,
 			})
 		}
 		return nil
@@ -206,7 +214,7 @@ func MapMaxLength[M ~map[K]V, K comparable, V any](limit int) govy.Rule[M] {
 		WithErrorCode(ErrorCodeMapMaxLength).
 		WithMessageTemplate(tpl).
 		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
-			MaxLength: limit,
+			ComparedValue: limit,
 		}))
 }
 

--- a/pkg/rules/one_of.go
+++ b/pkg/rules/one_of.go
@@ -107,12 +107,3 @@ func MutuallyExclusive[S any](required bool, getters map[string]func(s S) any) g
 				strings.Join(collections.SortedKeys(getters), ", "))
 		}())
 }
-
-func prettyOneOfList[T any](values []T) string {
-	b := strings.Builder{}
-	b.Grow(2 + len(values))
-	b.WriteString("[")
-	internal.PrettyStringListBuilder(&b, values, "")
-	b.WriteString("]")
-	return b.String()
-}

--- a/pkg/rules/one_of.go
+++ b/pkg/rules/one_of.go
@@ -1,38 +1,44 @@
 package rules
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
 
 	"github.com/nobl9/govy/internal"
 	"github.com/nobl9/govy/internal/collections"
+	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
 )
 
 // OneOf checks if the property's value matches one of the provided values.
 // The values must be comparable.
 func OneOf[T comparable](values ...T) govy.Rule[T] {
+	tpl := messagetemplates.Get(messagetemplates.OneOfTemplate)
+
 	return govy.NewRule(func(v T) error {
 		for i := range values {
 			if v == values[i] {
 				return nil
 			}
 		}
-		return errors.New("must be one of " + prettyOneOfList(values))
+		return govy.NewRuleErrorTemplate(govy.TemplateVars{
+			PropertyValue:   v,
+			ComparisonValue: values,
+		})
 	}).
 		WithErrorCode(ErrorCodeOneOf).
-		WithDescription(func() string {
-			b := strings.Builder{}
-			internal.PrettyStringListBuilder(&b, values, "")
-			return "must be one of: " + b.String()
-		}())
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: values,
+		}))
 }
 
 // OneOfProperties checks if at least one of the properties is set.
 // Property is considered set if its value is not empty (non-zero).
 func OneOfProperties[S any](getters map[string]func(s S) any) govy.Rule[S] {
+	tpl := messagetemplates.Get(messagetemplates.OneOfPropertiesTemplate)
+
 	return govy.NewRule(func(s S) error {
 		for _, getter := range getters {
 			v := getter(s)
@@ -40,15 +46,21 @@ func OneOfProperties[S any](getters map[string]func(s S) any) govy.Rule[S] {
 				return nil
 			}
 		}
-		return fmt.Errorf(
-			"one of %s properties must be set, none was provided",
-			prettyOneOfList(collections.SortedKeys(getters)))
+		return govy.NewRuleErrorTemplate(govy.TemplateVars{
+			PropertyValue:   s,
+			ComparisonValue: collections.SortedKeys(getters),
+		})
 	}).
 		WithErrorCode(ErrorCodeOneOfProperties).
-		WithDescription(func() string {
-			return fmt.Sprintf("at least one of the properties must be set: %s",
-				strings.Join(collections.SortedKeys(getters), ", "))
-		}())
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: collections.SortedKeys(getters),
+		}))
+}
+
+type mutuallyExclusiveTemplateVars struct {
+	// NoProperties is set to true if no properties were set and exactly one was required.
+	NoProperties bool
 }
 
 // MutuallyExclusive checks if properties are mutually exclusive.
@@ -56,6 +68,8 @@ func OneOfProperties[S any](getters map[string]func(s S) any) govy.Rule[S] {
 // Property is considered set if its value is not empty (non-zero).
 // If required is true, then a single non-empty property is required.
 func MutuallyExclusive[S any](required bool, getters map[string]func(s S) any) govy.Rule[S] {
+	tpl := messagetemplates.Get(messagetemplates.MutuallyExclusiveTemplate)
+
 	return govy.NewRule(func(s S) error {
 		var nonEmpty []string
 		for name, getter := range getters {
@@ -70,19 +84,24 @@ func MutuallyExclusive[S any](required bool, getters map[string]func(s S) any) g
 			if !required {
 				return nil
 			}
-			return fmt.Errorf(
-				"one of %s properties must be set, none was provided",
-				prettyOneOfList(collections.SortedKeys(getters)))
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: collections.SortedKeys(getters),
+				Custom:          mutuallyExclusiveTemplateVars{NoProperties: true},
+			})
 		case 1:
 			return nil
 		default:
 			slices.Sort(nonEmpty)
-			return fmt.Errorf(
-				"%s properties are mutually exclusive, provide only one of them",
-				prettyOneOfList(nonEmpty))
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: nonEmpty,
+				Custom:          mutuallyExclusiveTemplateVars{NoProperties: false},
+			})
 		}
 	}).
 		WithErrorCode(ErrorCodeMutuallyExclusive).
+		WithMessageTemplate(tpl).
 		WithDescription(func() string {
 			return fmt.Sprintf("properties are mutually exclusive: %s",
 				strings.Join(collections.SortedKeys(getters), ", "))

--- a/pkg/rules/one_of_test.go
+++ b/pkg/rules/one_of_test.go
@@ -14,7 +14,7 @@ var oneOfTestCases = []*struct {
 	expectedError string
 }{
 	{"that", []string{"this", "that"}, ""},
-	{"those", []string{"this", "that"}, "must be one of [this, that]"},
+	{"those", []string{"this", "that"}, "must be one of: this, that"},
 }
 
 func TestOneOf(t *testing.T) {

--- a/pkg/rules/required.go
+++ b/pkg/rules/required.go
@@ -2,20 +2,23 @@ package rules
 
 import (
 	"github.com/nobl9/govy/internal"
+	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
 )
 
 // Required ensures the property's value is not empty (i.e. it's not its type's zero value).
 func Required[T any]() govy.Rule[T] {
+	tpl := messagetemplates.Get(messagetemplates.RequiredTemplate)
+
 	return govy.NewRule(func(v T) error {
 		if internal.IsEmpty(v) {
-			return govy.NewRuleError(
-				internal.RequiredErrorMessage,
-				ErrorCodeRequired,
-			)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: v,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeRequired).
-		WithDescription("property is required")
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -120,7 +120,13 @@ func StringURL() govy.Rule[string] {
 				Error:         "failed to parse URL: " + err.Error(),
 			})
 		}
-		return validateURL(u)
+		if err = validateURL(u); err != nil {
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         err.Error(),
+			})
+		}
+		return nil
 	}).
 		WithErrorCode(ErrorCodeStringURL).
 		WithMessageTemplate(tpl).

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -14,50 +14,68 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/nobl9/govy/internal"
+	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
 )
 
 // StringNotEmpty ensures the property's value is not empty.
 // The string is considered empty if it contains only whitespace characters.
 func StringNotEmpty() govy.Rule[string] {
-	msg := "string cannot be empty"
+	tpl := messagetemplates.Get(messagetemplates.StringNonEmptyTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if len(strings.TrimSpace(s)) == 0 {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringNotEmpty).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringMatchRegexp ensures the property's value matches the regular expression.
 // The error message can be enhanced with examples of valid values.
 func StringMatchRegexp(re *regexp.Regexp) govy.Rule[string] {
-	msg := fmt.Sprintf("string must match regular expression: '%s'", re.String())
+	tpl := messagetemplates.Get(messagetemplates.StringMatchRegexpTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if !re.MatchString(s) {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: re.String(),
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringMatchRegexp).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: re.String(),
+		}))
 }
 
 // StringDenyRegexp ensures the property's value does not match the regular expression.
 // The error message can be enhanced with examples of invalid values.
 func StringDenyRegexp(re *regexp.Regexp) govy.Rule[string] {
-	msg := fmt.Sprintf("string must not match regular expression: '%s'", re.String())
+	tpl := messagetemplates.Get(messagetemplates.StringDenyRegexpTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if re.MatchString(s) {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: re.String(),
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringDenyRegexp).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: re.String(),
+		}))
 }
 
 // StringDNSLabel ensures the property's value is a valid DNS label as defined by RFC 1123.
@@ -73,120 +91,160 @@ func StringDNSLabel() govy.Rule[string] {
 // It follows RFC 5322 specification which is more permissive in regards to domain names.
 // Ref: https://www.ietf.org/rfc/rfc5322.txt
 func StringEmail() govy.Rule[string] {
-	msg := "string must be a valid email address"
+	tpl := messagetemplates.Get(messagetemplates.StringEmailTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if _, err := mail.ParseAddress(s); err != nil {
-			return fmt.Errorf("%s: %w", msg, err)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         err.Error(),
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringEmail).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription("string must be a valid email address")
 }
 
 // StringURL ensures property's value is a valid URL as defined by [url.Parse] function.
 // Unlike [URL] it does not impose any additional rules upon parsed [url.URL].
 func StringURL() govy.Rule[string] {
+	tpl := messagetemplates.Get(messagetemplates.URLTemplate)
+
 	return govy.NewRule(func(s string) error {
 		u, err := url.Parse(s)
 		if err != nil {
-			return fmt.Errorf("failed to parse URL: %w", err)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         "failed to parse URL: " + err.Error(),
+			})
 		}
 		return validateURL(u)
 	}).
 		WithErrorCode(ErrorCodeStringURL).
+		WithMessageTemplate(tpl).
 		WithDescription(urlDescription)
 }
 
 // StringMAC ensures property's value is a valid MAC address.
 func StringMAC() govy.Rule[string] {
-	msg := "string must be a valid MAC address"
+	tpl := messagetemplates.Get(messagetemplates.StringMACTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if _, err := net.ParseMAC(s); err != nil {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         err.Error(),
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringMAC).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringIP ensures property's value is a valid IP address.
 func StringIP() govy.Rule[string] {
-	msg := "string must be a valid IP address"
+	tpl := messagetemplates.Get(messagetemplates.StringIPTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if ip := net.ParseIP(s); ip == nil {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringIP).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringIPv4 ensures property's value is a valid IPv4 address.
 func StringIPv4() govy.Rule[string] {
-	msg := "string must be a valid IPv4 address"
+	tpl := messagetemplates.Get(messagetemplates.StringIPv4Template)
+
 	return govy.NewRule(func(s string) error {
 		if ip := net.ParseIP(s); ip == nil || ip.To4() == nil {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringIPv4).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringIPv6 ensures property's value is a valid IPv6 address.
 func StringIPv6() govy.Rule[string] {
-	msg := "string must be a valid IPv6 address"
+	tpl := messagetemplates.Get(messagetemplates.StringIPv6Template)
+
 	return govy.NewRule(func(s string) error {
 		if ip := net.ParseIP(s); ip == nil || ip.To4() != nil || len(ip) != net.IPv6len {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringIPv6).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringCIDR ensures property's value is a valid CIDR notation IP address.
 func StringCIDR() govy.Rule[string] {
-	msg := "string must be a valid CIDR notation IP address"
+	tpl := messagetemplates.Get(messagetemplates.StringCIDRTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if _, _, err := net.ParseCIDR(s); err != nil {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringCIDR).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringCIDRv4 ensures property's value is a valid CIDR notation IPv4 address.
 func StringCIDRv4() govy.Rule[string] {
-	msg := "string must be a valid CIDR notation IPv4 address"
+	tpl := messagetemplates.Get(messagetemplates.StringCIDRv4Template)
+
 	return govy.NewRule(func(s string) error {
 		if ip, ipNet, err := net.ParseCIDR(s); err != nil || ip.To4() == nil || !ipNet.IP.Equal(ip) {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringCIDRv4).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringCIDRv6 ensures property's value is a valid CIDR notation IPv6 address.
 func StringCIDRv6() govy.Rule[string] {
-	msg := "string must be a valid CIDR notation IPv6 address"
+	tpl := messagetemplates.Get(messagetemplates.StringCIDRv6Template)
+
 	return govy.NewRule(func(s string) error {
 		if ip, _, err := net.ParseCIDR(s); err != nil || ip.To4() != nil || len(ip) != net.IPv6len {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringCIDRv6).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringUUID ensures property's value is a valid UUID string as defined by RFC 4122.
@@ -210,20 +268,25 @@ func StringASCII() govy.Rule[string] {
 
 // StringJSON ensures property's value is a valid JSON literal.
 func StringJSON() govy.Rule[string] {
-	msg := "string must be a valid JSON"
+	tpl := messagetemplates.Get(messagetemplates.StringJSONTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if !json.Valid([]byte(s)) {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringJSON).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringContains ensures the property's value contains all the provided substrings.
 func StringContains(substrings ...string) govy.Rule[string] {
-	msg := "string must contain the following substrings: " + prettyStringList(substrings)
+	tpl := messagetemplates.Get(messagetemplates.StringContainsTemplate)
+
 	return govy.NewRule(func(s string) error {
 		matched := true
 		for _, substr := range substrings {
@@ -233,37 +296,46 @@ func StringContains(substrings ...string) govy.Rule[string] {
 			}
 		}
 		if !matched {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: substrings,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringContains).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: substrings,
+		}))
 }
 
 // StringExcludes ensures the property's value does not contain any of the provided substrings.
 func StringExcludes(substrings ...string) govy.Rule[string] {
-	msg := "string must not contain any of the following substrings: " + prettyStringList(substrings)
+	tpl := messagetemplates.Get(messagetemplates.StringExcludesTemplate)
+
 	return govy.NewRule(func(s string) error {
 		for _, substr := range substrings {
 			if strings.Contains(s, substr) {
-				return errors.New(msg)
+				return govy.NewRuleErrorTemplate(govy.TemplateVars{
+					PropertyValue:   s,
+					ComparisonValue: substrings,
+				})
 			}
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringExcludes).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: substrings,
+		}))
 }
 
 // StringStartsWith ensures the property's value starts with one of the provided prefixes.
 func StringStartsWith(prefixes ...string) govy.Rule[string] {
-	var msg string
-	if len(prefixes) == 1 {
-		msg = fmt.Sprintf("string must start with '%s' prefix", prefixes[0])
-	} else {
-		msg = "string must start with one of the following prefixes: " + prettyStringList(prefixes)
-	}
+	tpl := messagetemplates.Get(messagetemplates.StringStartsWithTemplate)
+
 	return govy.NewRule(func(s string) error {
 		matched := false
 		for _, prefix := range prefixes {
@@ -273,22 +345,24 @@ func StringStartsWith(prefixes ...string) govy.Rule[string] {
 			}
 		}
 		if !matched {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: prefixes,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringStartsWith).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: prefixes,
+		}))
 }
 
 // StringEndsWith ensures the property's value ends with one of the provided suffixes.
 func StringEndsWith(suffixes ...string) govy.Rule[string] {
-	var msg string
-	if len(suffixes) == 1 {
-		msg = fmt.Sprintf("string must end with '%s' suffix", suffixes[0])
-	} else {
-		msg = "string must end with one of the following suffixes: " + prettyStringList(suffixes)
-	}
+	tpl := messagetemplates.Get(messagetemplates.StringEndsWithTemplate)
+
 	return govy.NewRule(func(s string) error {
 		matched := false
 		for _, suffix := range suffixes {
@@ -298,26 +372,37 @@ func StringEndsWith(suffixes ...string) govy.Rule[string] {
 			}
 		}
 		if !matched {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: suffixes,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringEndsWith).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: suffixes,
+		}))
 }
 
 // StringTitle ensures each word in a string starts with a capital letter.
 func StringTitle() govy.Rule[string] {
-	msg := "each word in a string must start with a capital letter"
+	tpl := messagetemplates.Get(messagetemplates.StringTitleTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if len(s) == 0 {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		prev := ' '
 		for _, r := range s {
 			if isStringSeparator(prev) {
 				if !unicode.IsUpper(r) && !isStringSeparator(r) {
-					return errors.New(msg)
+					return govy.NewRuleErrorTemplate(govy.TemplateVars{
+						PropertyValue: s,
+					})
 				}
 			}
 			prev = r
@@ -325,18 +410,18 @@ func StringTitle() govy.Rule[string] {
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringTitle).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
-// StringGitRef errors.
-var (
-	errGitRefEmpty           = errors.New("git reference cannot be empty")
-	errGitRefEndsWithDot     = errors.New("git reference must not end with a '.'")
-	errGitRefAtLeastOneSlash = errors.New("git reference must contain at least one '/'")
-	errGitRefEmptyPart       = errors.New("git reference must not have empty parts")
-	errGitRefStartsWithDash  = errors.New("git branch and tag references must not start with '-'")
-	errGitRefForbiddenChars  = errors.New("git reference contains forbidden characters")
-)
+type stringGitRefTemplateVars struct {
+	GitRefEmpty           bool
+	GitRefEndsWithDot     bool
+	GitRefAtLeastOneSlash bool
+	GitRefEmptyPart       bool
+	GitRefStartsWithDash  bool
+	GitRefForbiddenChars  bool
+}
 
 // StringGitRef ensures a git reference name follows the [git-check-ref-format] rules.
 //
@@ -364,64 +449,93 @@ var (
 // [git-check-ref-format] :https://git-scm.com/docs/git-check-ref-format
 // [go-git]: https://github.com/go-git/go-git/blob/95afe7e1cdf71c59ee8a71971fac71880020a744/plumbing/reference.go#L167
 func StringGitRef() govy.Rule[string] {
-	msg := "string must be a valid git reference"
+	tpl := messagetemplates.Get(messagetemplates.StringGitRefTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if len(s) == 0 {
-			return errGitRefEmpty
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Custom:        stringGitRefTemplateVars{GitRefEmpty: true},
+			})
 		}
 		if s == "HEAD" {
 			return nil
 		}
 		if strings.HasSuffix(s, ".") {
-			return errGitRefEndsWithDot
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Custom:        stringGitRefTemplateVars{GitRefEndsWithDot: true},
+			})
 		}
 		parts := strings.Split(s, "/")
 		if len(parts) < 2 {
-			return errGitRefAtLeastOneSlash
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Custom:        stringGitRefTemplateVars{GitRefAtLeastOneSlash: true},
+			})
 		}
 		isBranch := strings.HasPrefix(s, "refs/heads/")
 		isTag := strings.HasPrefix(s, "refs/tags/")
 		for _, part := range parts {
 			if len(part) == 0 {
-				return errGitRefEmptyPart
+				return govy.NewRuleErrorTemplate(govy.TemplateVars{
+					PropertyValue: s,
+					Custom:        stringGitRefTemplateVars{GitRefEmptyPart: true},
+				})
 			}
 			if (isBranch || isTag) && strings.HasPrefix(part, "-") {
-				return errGitRefStartsWithDash
+				return govy.NewRuleErrorTemplate(govy.TemplateVars{
+					PropertyValue: s,
+					Custom:        stringGitRefTemplateVars{GitRefStartsWithDash: true},
+				})
 			}
 			if part == "@" ||
 				strings.HasPrefix(part, ".") ||
 				strings.HasSuffix(part, ".lock") ||
 				stringContainsGitRefForbiddenChars(part) {
-				return errGitRefForbiddenChars
+				return govy.NewRuleErrorTemplate(govy.TemplateVars{
+					PropertyValue: s,
+					Custom:        stringGitRefTemplateVars{GitRefForbiddenChars: true},
+				})
 			}
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringGitRef).
+		WithMessageTemplate(tpl).
 		WithDetails("see https://git-scm.com/docs/git-check-ref-format for more information on Git reference naming rules").
-		WithDescription(msg)
+		WithDescription("string must be a valid git reference")
 }
 
 // StringFileSystemPath ensures the property's value is an existing file system path.
 func StringFileSystemPath() govy.Rule[string] {
-	msg := "string must be an existing file system path"
+	tpl := messagetemplates.Get(messagetemplates.StringFileSystemPathTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if _, err := osStatFile(s); err != nil {
-			return handleFilePathError(err, msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         handleFilePathError(err).Error(),
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringFileSystemPath).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringFilePath ensures the property's value is a file system path pointing to an existing file.
 func StringFilePath() govy.Rule[string] {
-	msg := "string must be a file system path to an existing file"
+	tpl := messagetemplates.Get(messagetemplates.StringFilePathTemplate)
+
 	return govy.NewRule(func(s string) error {
 		info, err := osStatFile(s)
 		if err != nil {
-			return handleFilePathError(err, msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         handleFilePathError(err).Error(),
+			})
 		}
 		if info.IsDir() {
 			return errFilePathNotFile
@@ -429,16 +543,21 @@ func StringFilePath() govy.Rule[string] {
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringFilePath).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringDirPath ensures the property's value is a file system path pointing to an existing directory.
 func StringDirPath() govy.Rule[string] {
-	msg := "string must be a file system path to an existing directory"
+	tpl := messagetemplates.Get(messagetemplates.StringDirPathTemplate)
+
 	return govy.NewRule(func(s string) error {
 		info, err := osStatFile(s)
 		if err != nil {
-			return handleFilePathError(err, msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         handleFilePathError(err).Error(),
+			})
 		}
 		if !info.IsDir() {
 			return errFilePathNotDir
@@ -446,7 +565,8 @@ func StringDirPath() govy.Rule[string] {
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringDirPath).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringMatchFileSystemPath ensures the property's value matches the provided file path pattern.
@@ -454,19 +574,30 @@ func StringDirPath() govy.Rule[string] {
 // most notably it does not support '**' recursive expansion.
 // It does not check if the file path exists on the file system.
 func StringMatchFileSystemPath(pattern string) govy.Rule[string] {
-	msg := fmt.Sprintf("string must match file path pattern: '%s'", pattern)
+	tpl := messagetemplates.Get(messagetemplates.StringMatchFileSystemPathTemplate)
+
 	return govy.NewRule(func(s string) error {
 		ok, err := filepath.Match(pattern, s)
 		if err != nil {
-			return err
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: pattern,
+				Error:           err.Error(),
+			})
 		}
 		if !ok {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				ComparisonValue: pattern,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringMatchFileSystemPath).
-		WithDescription(msg)
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: pattern,
+		}))
 }
 
 // StringRegexp ensures the property's value is a valid regular expression.
@@ -476,17 +607,22 @@ func StringMatchFileSystemPath(pattern string) govy.Rule[string] {
 //
 // [regexp/syntax]: https://pkg.go.dev/regexp/syntax
 func StringRegexp() govy.Rule[string] {
-	msg := "string must be a valid regular expression"
+	tpl := messagetemplates.Get(messagetemplates.StringRegexpTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if _, err := regexp.Compile(s); err != nil {
-			return fmt.Errorf("%s: %w", msg, err)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         err.Error(),
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringRegexp).
+		WithMessageTemplate(tpl).
 		// nolint: lll
 		WithDetails(`the regular expression syntax must comply to RE2, it is described at https://golang.org/s/re2syntax, except for \C; for an overview of the syntax, see https://pkg.go.dev/regexp/syntax`).
-		WithDescription(msg)
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringCrontab ensures the property's value is a valid crontab schedule expression.
@@ -495,10 +631,20 @@ func StringRegexp() govy.Rule[string] {
 // [crontab manual]: https://www.man7.org/linux/man-pages/man5/crontab.5.html
 // [crontab.guru]: https://crontab.guru
 func StringCrontab() govy.Rule[string] {
-	msg := "string must be a valid cron schedule expression"
-	return govy.NewRule(parseCrontab).
-		WithMessage(msg).
-		WithErrorCode(ErrorCodeStringCrontab)
+	tpl := messagetemplates.Get(messagetemplates.StringCrontabTemplate)
+
+	return govy.NewRule(func(s string) error {
+		if err := parseCrontab(s); err != nil {
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         err.Error(),
+			})
+		}
+		return nil
+	}).
+		WithErrorCode(ErrorCodeStringCrontab).
+		WithMessageTemplate(tpl).
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringDateTime ensures the property's value is a valid date and time in the specified layout.
@@ -506,16 +652,24 @@ func StringCrontab() govy.Rule[string] {
 // The layout must be a valid time format string as defined by [time.Parse],
 // an example of which is [time.RFC3339].
 func StringDateTime(layout string) govy.Rule[string] {
-	msg := fmt.Sprintf("string must be a valid date and time in '%s' format", layout)
+	tpl := messagetemplates.Get(messagetemplates.StringDateTimeTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if _, err := time.Parse(layout, s); err != nil {
-			return fmt.Errorf("%s: %w", msg, err)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue:   s,
+				Error:           err.Error(),
+				ComparisonValue: layout,
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringDateTime).
+		WithMessageTemplate(tpl).
 		WithDetails("date and time format follows Go's time layout, see https://pkg.go.dev/time#Layout for more details").
-		WithDescription(msg)
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{
+			ComparisonValue: layout,
+		}))
 }
 
 // StringTimeZone ensures the property's value is a valid time zone name which
@@ -530,19 +684,26 @@ func StringDateTime(layout string) govy.Rule[string] {
 // [time.LoadLocation] looks for the IANA Time Zone database in specific places,
 // please refer to its documentation for more information.
 func StringTimeZone() govy.Rule[string] {
-	msg := "string must be a valid IANA Time Zone Database code"
+	tpl := messagetemplates.Get(messagetemplates.StringTimeZoneTemplate)
+
 	return govy.NewRule(func(s string) error {
 		if s == "" || s == "Local" {
-			return errors.New(msg)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+			})
 		}
 		if _, err := time.LoadLocation(s); err != nil {
-			return fmt.Errorf("%s: %w", msg, err)
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				PropertyValue: s,
+				Error:         err.Error(),
+			})
 		}
 		return nil
 	}).
 		WithErrorCode(ErrorCodeStringTimeZone).
+		WithMessageTemplate(tpl).
 		WithExamples("UTC", "America/New_York", "Europe/Warsaw").
-		WithDescription(msg)
+		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
 }
 
 // StringAlpha ensures the property's value consists only of ASCII letters.
@@ -645,22 +806,16 @@ var (
 	errFilePathNotDir    = errors.New("path must point to a directory and not to a file")
 )
 
-func handleFilePathError(err error, msg string) error {
+func handleFilePathError(err error) error {
 	var pathErr *os.PathError
 	if !errors.As(err, &pathErr) {
 		return err
 	}
 	if errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("%s: %w", msg, errFilePathNotExists)
+		return errFilePathNotExists
 	}
 	if errors.Is(err, os.ErrPermission) {
-		return fmt.Errorf("%s: %w", msg, errFilePathNoPerm)
+		return errFilePathNoPerm
 	}
-	return fmt.Errorf("%s: %w", msg, err)
-}
-
-func prettyStringList[T any](values []T) string {
-	b := new(strings.Builder)
-	internal.PrettyStringListBuilder(b, values, "'")
-	return b.String()
+	return err
 }

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -894,6 +895,15 @@ func BenchmarkStringTitle(b *testing.B) {
 		}
 	}
 }
+
+var (
+	errGitRefEmpty           = errors.New("git reference cannot be empty")
+	errGitRefEndsWithDot     = errors.New("git reference must not end with a '.'")
+	errGitRefAtLeastOneSlash = errors.New("git reference must contain at least one '/'")
+	errGitRefEmptyPart       = errors.New("git reference must not have empty parts")
+	errGitRefStartsWithDash  = errors.New("git branch and tag references must not start with '-'")
+	errGitRefForbiddenChars  = errors.New("git reference contains forbidden characters")
+)
 
 var stringGitRefTestCases = []*struct {
 	in          string

--- a/pkg/rules/url.go
+++ b/pkg/rules/url.go
@@ -1,17 +1,20 @@
 package rules
 
 import (
-	"errors"
 	"net/url"
 
+	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
 )
 
 // URL ensures the URL is valid.
 // The URL must have a scheme (e.g. https://) and contain either host, fragment or opaque data.
 func URL() govy.Rule[*url.URL] {
+	tpl := messagetemplates.Get(messagetemplates.URLTemplate)
+
 	return govy.NewRule(validateURL).
 		WithErrorCode(ErrorCodeURL).
+		WithMessageTemplate(tpl).
 		WithDescription(urlDescription)
 }
 
@@ -19,10 +22,16 @@ const urlDescription = "valid URL must have a scheme (e.g. https://) and contain
 
 func validateURL(u *url.URL) error {
 	if u.Scheme == "" {
-		return errors.New("valid URL must have a scheme (e.g. https://)")
+		return govy.NewRuleErrorTemplate(govy.TemplateVars{
+			PropertyValue: u.String(),
+			Error:         "valid URL must have a scheme (e.g. https://)",
+		})
 	}
 	if u.Host == "" && u.Fragment == "" && u.Opaque == "" {
-		return errors.New("valid URL must contain either host, fragment or opaque data")
+		return govy.NewRuleErrorTemplate(govy.TemplateVars{
+			PropertyValue: u.String(),
+			Error:         "valid URL must contain either host, fragment or opaque data",
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
Added templates support to all the builtin rules.

## Breaking Changes

`rules.OneOf` error has been changed, instead of `must be one of [this, that]` it will now return `must be one of: this, that`.