### PR TITLE
fix: Correct joinStringSlice template function usage

### DIFF
--- a/internal/messagetemplates/functions_test.go
+++ b/internal/messagetemplates/functions_test.go
@@ -14,6 +14,7 @@ import (
 
 type templateVariables struct {
 	Examples  []string
+	Values    any
 	Details   string
 	MinLength int
 	MaxLength int
@@ -47,26 +48,31 @@ func TestAddFunctions(t *testing.T) {
 				Expected: "(e.g. 'foo', 'bar', 'baz')",
 			},
 		},
-		"joinStringSlice": {
+		"joinSlice": {
 			{
-				Text:     `{{ joinStringSlice .Examples "'" }}`,
+				Text:     `{{ joinSlice .Examples "'" }}`,
 				Vars:     templateVariables{Examples: nil},
 				Expected: "",
 			},
 			{
-				Text:     `{{ joinStringSlice .Examples "'" }}`,
+				Text:     `{{ joinSlice .Examples "'" }}`,
 				Vars:     templateVariables{Examples: []string{}},
 				Expected: "",
 			},
 			{
-				Text:     `{{ joinStringSlice .Examples "'" }}`,
+				Text:     `{{ joinSlice .Examples "'" }}`,
 				Vars:     templateVariables{Examples: []string{"foo"}},
 				Expected: "'foo'",
 			},
 			{
-				Text:     `{{ joinStringSlice .Examples "'" }}`,
+				Text:     `{{ joinSlice .Examples "'" }}`,
 				Vars:     templateVariables{Examples: []string{"foo", "bar", "baz"}},
 				Expected: "'foo', 'bar', 'baz'",
+			},
+			{
+				Text:     `{{ joinSlice .Values "'" }}`,
+				Vars:     templateVariables{Values: []int{1, 2, 3}},
+				Expected: "'1', '2', '3'",
 			},
 		},
 	}

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -63,16 +63,16 @@ var rawMessageTemplates = map[templateKey]string{
 	GTETemplate:               "should be greater than or equal to '{{ .ComparisonValue }}'",
 	LTTemplate:                "should be less than '{{ .ComparisonValue }}'",
 	LTETemplate:               "should be less than or equal to '{{ .ComparisonValue }}'",
-	EqualPropertiesTemplate:   `all of [{{ joinStringSlice .ComparisonValue "" }}] properties must be equal, but '{{ .Custom.FirstNotEqual }}' is not equal to '{{ .Custom.SecondNotEqual }}'`,
+	EqualPropertiesTemplate:   `all of [{{ joinSlice .ComparisonValue "" }}] properties must be equal, but '{{ .Custom.FirstNotEqual }}' is not equal to '{{ .Custom.SecondNotEqual }}'`,
 	DurationPrecisionTemplate: "duration must be defined with {{ .ComparisonValue }} precision",
 	ForbiddenTemplate:         "property is forbidden",
-	OneOfTemplate:             `must be one of: {{ joinStringSlice .ComparisonValue "" }}`,
-	OneOfPropertiesTemplate:   `one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided`,
+	OneOfTemplate:             `must be one of: {{ joinSlice .ComparisonValue "" }}`,
+	OneOfPropertiesTemplate:   `one of [{{ joinSlice .ComparisonValue "" }}] properties must be set, none was provided`,
 	MutuallyExclusiveTemplate: `
 {{- if .Custom.NoProperties -}}
-one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none was provided
+one of [{{ joinSlice .ComparisonValue "" }}] properties must be set, none was provided
 {{- else -}}
-[{{ joinStringSlice .ComparisonValue "" }}] properties are mutually exclusive, provide only one of them
+[{{ joinSlice .ComparisonValue "" }}] properties are mutually exclusive, provide only one of them
 {{- end }}`,
 	RequiredTemplate:          internal.RequiredErrorMessage,
 	StringNonEmptyTemplate:    "string cannot be empty",
@@ -87,20 +87,20 @@ one of [{{ joinStringSlice .ComparisonValue "" }}] properties must be set, none 
 	StringCIDRv4Template:      "string must be a valid CIDR notation IPv4 address",
 	StringCIDRv6Template:      "string must be a valid CIDR notation IPv6 address",
 	StringJSONTemplate:        "string must be a valid JSON",
-	StringContainsTemplate:    `string must contain the following substrings: {{ joinStringSlice .ComparisonValue "'" }}`,
-	StringExcludesTemplate:    `string must not contain any of the following substrings: {{ joinStringSlice .ComparisonValue "'" }}`,
+	StringContainsTemplate:    `string must contain the following substrings: {{ joinSlice .ComparisonValue "'" }}`,
+	StringExcludesTemplate:    `string must not contain any of the following substrings: {{ joinSlice .ComparisonValue "'" }}`,
 	StringStartsWithTemplate: `
 {{- if eq (len .ComparisonValue) 1 -}}
 string must start with '{{ index .ComparisonValue 0 }}' prefix
 {{- else -}}
-string must start with one of the following prefixes: {{ joinStringSlice .ComparisonValue "'" }}
+string must start with one of the following prefixes: {{ joinSlice .ComparisonValue "'" }}
 {{- end }}
 `,
 	StringEndsWithTemplate: `
 {{- if eq (len .ComparisonValue) 1 -}}
 string must end with '{{ index .ComparisonValue 0 }}' suffix
 {{- else -}}
-string must end with one of the following suffixes: {{ joinStringSlice .ComparisonValue "'" }}
+string must end with one of the following suffixes: {{ joinSlice .ComparisonValue "'" }}
 {{- end }}
 `,
 	StringTitleTemplate: "each word in a string must start with a capital letter",
@@ -130,7 +130,7 @@ string must be a valid git reference
 	StringDateTimeTemplate:            "string must be a valid date and time in '{{ .ComparisonValue }}' format{{- if .Error }}: {{ .Error }}{{- end }}",
 	StringTimeZoneTemplate:            "string must be a valid IANA Time Zone Database code{{- if .Error }}: {{ .Error }}{{- end }}",
 	SliceUniqueTemplate: `elements are not unique, {{ .Custom.FirstOrdinal }} and {{ .Custom.SecondOrdinal }} elements collide
-{{- if gt (len .Custom.Constraints) 0 }} based on constraints: {{ joinStringSlice .Custom.Constraints "" }}{{- end }}`,
+{{- if gt (len .Custom.Constraints) 0 }} based on constraints: {{ joinSlice .Custom.Constraints "" }}{{- end }}`,
 	URLTemplate: "{{ .Error }}",
 }
 

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -794,8 +794,8 @@ func ExampleAddTemplateFunctions_formatExamples() {
 	// (e.g. 'Joanna', 'Angeline')
 }
 
-func ExampleAddTemplateFunctions_joinStringSlice() {
-	tplString := `{{ joinStringSlice .Slice "'" }}`
+func ExampleAddTemplateFunctions_joinSlice() {
+	tplString := `{{ joinSlice .Slice "'" }}`
 	tpl := template.New("")
 	tpl = govy.AddTemplateFunctions(tpl)
 	tpl = template.Must(tpl.Parse(tplString))

--- a/pkg/govy/message_templates.go
+++ b/pkg/govy/message_templates.go
@@ -15,9 +15,9 @@ import (
 //     as a single string representation.
 //     Example: `{{ formatExamples ["foo", "bar"] }}` -> "(e.g. 'foo', 'bar')"
 //
-//   - 'joinStringSlice' joins a list of strings into a comma separated list of values.
+//   - 'joinSlice' joins a list of strings into a comma separated list of values.
 //     Its second argument determines a surrounding string for each value.
-//     Example: `{{ joinStringSlice ["foo", "bar"] "'" }}` -> "'foo', 'bar'"
+//     Example: `{{ joinSlice ["foo", "bar"] "'" }}` -> "'foo', 'bar'"
 //
 // Refer to the testable examples of [AddTemplateFunctions] for more details
 // on each builtin function.

--- a/pkg/govy/message_templates.go
+++ b/pkg/govy/message_templates.go
@@ -15,8 +15,8 @@ import (
 //     as a single string representation.
 //     Example: `{{ formatExamples ["foo", "bar"] }}` -> "(e.g. 'foo', 'bar')"
 //
-//   - 'joinSlice' joins a list of strings into a comma separated list of values.
-//     Its second argument determines a surrounding string for each value.
+//   - 'joinSlice' joins a list of values into a comma separated list of strings.
+//     Its second argument determines the surrounding string for each value.
 //     Example: `{{ joinSlice ["foo", "bar"] "'" }}` -> "'foo', 'bar'"
 //
 // Refer to the testable examples of [AddTemplateFunctions] for more details


### PR DESCRIPTION
## Motivation

Rules which used `joinStringSlice` template function and passed a variable slice type to it were prone to failure, example for `rules.OneOf` defined for a slice of integers:

```text
failed to execute message template: template: :1:35: executing "" at <.ComparisonValue>: wrong type for value; expected []string; got []int
```

## Release Notes

Template function `joinStringSlice` was renamed to `joinSlice` and it now accepts any kind of slice, not only a slice of strings.

## Breaking Changes

Changed template function name from `joinStringSlice` to `joinSlice` to better reflect its usage.
