### PR TITLE
chore: Pin devbox version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,7 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.12.0
         with:
           enable-cache: true
+          devbox-version: ${{ vars.DEVBOX_VERSION }}
       - name: Run spell and markdown checkers
         run: devbox run -- make check/spell check/trailing check/markdown
       - name: Check generated code

--- a/.github/workflows/coverage-and-benchmark.yml
+++ b/.github/workflows/coverage-and-benchmark.yml
@@ -17,6 +17,7 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.12.0
         with:
           enable-cache: true
+          devbox-version: ${{ vars.DEVBOX_VERSION }}
       - name: Update coverage report
         uses: ncruces/go-coverage-report@v0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.12.0
         with:
           enable-cache: true
+          devbox-version: ${{ vars.DEVBOX_VERSION }}
       - name: Run unit tests
         run: devbox run -- make test
       - name: Run benchmark

--- a/.github/workflows/vulns.yml
+++ b/.github/workflows/vulns.yml
@@ -20,5 +20,6 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.12.0
         with:
           enable-cache: true
+          devbox-version: ${{ vars.DEVBOX_VERSION }}
       - name: Run vulnerability check
         run: devbox run -- make check/vulns


### PR DESCRIPTION
Current latest version is 0.14.0 but the `devbox.lock` file was created with devbox version 0.13.7.
While this shouldn't matter for some reason the lock file is being updated in GH actions when merging to main.
This PR is an attempt at fixing this.