### PR TITLE
chore: Simplify internal rules iteration withing PropertyRules

### DIFF
--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -3,6 +3,7 @@ package govy
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -128,7 +129,7 @@ outer:
 	return agg
 }
 
-func NewPropertyError(propertyName string, propertyValue interface{}, errs ...error) *PropertyError {
+func NewPropertyError(propertyName string, propertyValue any, errs ...error) *PropertyError {
 	return &PropertyError{
 		PropertyName:  propertyName,
 		PropertyValue: internal.PropertyValueString(propertyValue),
@@ -334,10 +335,8 @@ func HasErrorCode(err error, code ErrorCode) bool {
 		}
 	case *RuleError:
 		codes := strings.Split(v.Code, ErrorCodeSeparator)
-		for i := range codes {
-			if code == codes[i] {
-				return true
-			}
+		if slices.Contains(codes, code) {
+			return true
 		}
 	case RuleSetError:
 		for _, e := range v {

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -2,11 +2,8 @@ package govy
 
 import (
 	"errors"
-	"fmt"
-	"log/slog"
 
 	"github.com/nobl9/govy/internal"
-	"github.com/nobl9/govy/internal/logging"
 )
 
 // For creates a new [PropertyRules] instance for the property
@@ -92,7 +89,7 @@ type PropertyRules[T, S any] struct {
 	name            string
 	getter          internalPropertyGetter[T, S]
 	transformGetter internalTransformPropertyGetter[T, S]
-	steps           []interface{}
+	rules           []validationInterface[T]
 	required        bool
 	omitEmpty       bool
 	hideValue       bool
@@ -123,13 +120,8 @@ func (r PropertyRules[T, S]) Validate(st S) error {
 	if skip {
 		return nil
 	}
-	for _, step := range r.steps {
-		vi, ok := step.(validationInterface[T])
-		if !ok {
-			logging.Logger().Error("unexpected type", slog.String("type", fmt.Sprintf("%T", step)))
-			continue
-		}
-		err := vi.Validate(propValue)
+	for i := range r.rules {
+		err := r.rules[i].Validate(propValue)
 		if err == nil {
 			continue
 		}
@@ -175,13 +167,15 @@ func (r PropertyRules[T, S]) WithExamples(examples ...string) PropertyRules[T, S
 
 // Rules associates provided [Rule] with the property.
 func (r PropertyRules[T, S]) Rules(rules ...validationInterface[T]) PropertyRules[T, S] {
-	r.steps = appendSteps(r.steps, rules)
+	r.rules = append(r.rules, rules...)
 	return r
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
 func (r PropertyRules[T, S]) Include(rules ...Validator[T]) PropertyRules[T, S] {
-	r.steps = appendSteps(r.steps, rules)
+	for _, rule := range rules {
+		r.rules = append(r.rules, rule)
+	}
 	return r
 }
 
@@ -246,23 +240,16 @@ func (r PropertyRules[T, S]) plan(builder planBuilder) {
 		builder.propertyPlan.Package = typInfo.Package
 	}
 	builder = builder.appendPath(r.name).setExamples(r.examples...)
-	for _, step := range r.steps {
+	for _, step := range r.rules {
 		if p, ok := step.(planner); ok {
 			p.plan(builder)
 		}
 	}
 	// If we don't have any rules defined for this property, append it nonetheless.
 	// It can be useful when we have things like [WithExamples] or [Required] set.
-	if len(r.steps) == 0 {
+	if len(r.rules) == 0 {
 		*builder.children = append(*builder.children, builder)
 	}
-}
-
-func appendSteps[T any](slice []interface{}, steps []T) []interface{} {
-	for _, step := range steps {
-		slice = append(slice, step)
-	}
-	return slice
 }
 
 // getValue extracts the property value from the provided property.
@@ -281,7 +268,7 @@ func (r PropertyRules[T, S]) getValue(st S) (v T, skip bool, propErr *PropertyEr
 	isEmptyError := errors.Is(err, emptyErr{})
 	// Any error other than [emptyErr] is considered critical, we don't proceed with validation.
 	if err != nil && !isEmptyError {
-		var propValue interface{}
+		var propValue any
 		// If the value was transformed, we need to set the property value to the original, pre-transformed one.
 		if HasErrorCode(err, ErrorCodeTransform) {
 			propValue = originalValue

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -195,13 +195,13 @@ func (r PropertyRulesForMap[M, K, V, S]) plan(builder planBuilder) {
 	r.mapRules.plan(builder.setExamples(r.mapRules.examples...))
 	builder = builder.appendPath(r.mapRules.name)
 	// JSON/YAML path for keys uses '~' to extract the keys.
-	if len(r.forKeyRules.steps) > 0 {
+	if len(r.forKeyRules.rules) > 0 {
 		r.forKeyRules.plan(builder.appendPath("~"))
 	}
-	if len(r.forValueRules.steps) > 0 {
+	if len(r.forValueRules.rules) > 0 {
 		r.forValueRules.plan(builder.appendPath("*"))
 	}
-	if len(r.forItemRules.steps) > 0 {
+	if len(r.forItemRules.rules) > 0 {
 		r.forItemRules.plan(builder.appendPath("*"))
 	}
 }

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -126,7 +126,7 @@ func (r PropertyRulesForSlice[T, S]) plan(builder planBuilder) {
 	}
 	r.sliceRules.plan(builder.setExamples(r.sliceRules.examples...))
 	builder = builder.appendPath(r.sliceRules.name)
-	if len(r.forEachRules.steps) > 0 {
+	if len(r.forEachRules.rules) > 0 {
 		r.forEachRules.plan(builder.appendPath("[*]"))
 	}
 }


### PR DESCRIPTION
## Motivation

Previously the `steps` property of `PropertyRules` used to contain different kinds of actions, like conditions, flow control and validation rules.
When the logic was cleaned and only rules remained the field was left intact as `[]interface{}`.
That is no longer necessary and we can safely convert it to a strictly typed `[]validationInterface[T]`.