### PR TITLE
feat: Add cascade mode to govy.RuleSet

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,9 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/9bc8a90931262245919a26f995c1f24c6c70d3fe?lastModified=1742237028&narHash=sha256-xlpHmgBxUnvHo8FNnju0sgnEyasb4gC607b%2BkeqjmX8%3D"
+    },
     "go@1.22": {
       "last_modified": "2025-02-07T11:26:36Z",
       "resolved": "github:NixOS/nixpkgs/d98abf5cf5914e5e4e9d57205e3af55ca90ffc1d#go_1_22",

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -957,6 +957,42 @@ func ExampleRuleSetToPointer() {
 	//     - string must end with 'o' suffix
 }
 
+// If you wish to control how rules aggregated by [govy.RuleSet] evaluate
+// you can use [govy.RuleSet.Cascade] to set a [govy.CascadeMode].
+//
+// Similar to how the cascade mode works when evaluating [govy.PropertyRules],
+// the [govy.CascadeModeStop] will stop validation after the first encountered error.
+//
+// In the example below we can see that although both rules should fail,
+// only the first one (order of definitions matters here!) returns an error.
+func ExampleRuleSet_Cascade() {
+	teacherNameRule := govy.NewRuleSet(
+		rules.StringLength(1, 5),
+		rules.StringMatchRegexp(regexp.MustCompile("^(Tom|Jerry)$")),
+	).
+		Cascade(govy.CascadeModeStop)
+
+	v := govy.New(
+		govy.For(func(t Teacher) string { return t.Name }).
+			WithName("name").
+			Rules(teacherNameRule),
+	).WithName("Teacher")
+
+	teacher := Teacher{
+		Name: "Jonathan",
+	}
+
+	err := v.Validate(teacher)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// Validation for Teacher has failed for the following properties:
+	//   - 'name' with value 'Jonathan':
+	//     - length must be between 1 and 5
+}
+
 // To inspect if an error contains a given [govy.ErrorCode], use [govy.HasErrorCode] function.
 // This function will also return true if the expected [govy.ErrorCode]
 // is part of a chain of wrapped error codes.

--- a/pkg/govy/rule_set.go
+++ b/pkg/govy/rule_set.go
@@ -24,29 +24,36 @@ func RuleSetToPointer[T any](ruleSet RuleSet[T]) RuleSet[*T] {
 type RuleSet[T any] struct {
 	rules     []Rule[T]
 	errorCode ErrorCode
+	mode      CascadeMode
 }
 
 // Validate works the same way as [Rule.Validate],
 // except each aggregated rule is validated individually.
-// The errors are aggregated and returned as a single error which serves as a container for them.
+// The errors are aggregated and returned as a single [RuleSetError]
+// which serves as a container for them.
 func (r RuleSet[T]) Validate(v T) error {
 	var errs RuleSetError
 	for i := range r.rules {
-		if err := r.rules[i].Validate(v); err != nil {
-			switch ev := err.(type) {
-			case *RuleError:
-				errs = append(errs, ev.AddCode(r.errorCode))
-			case *PropertyError:
-				for _, e := range ev.Errors {
-					_ = e.AddCode(r.errorCode)
-				}
-				errs = append(errs, ev)
-			default:
-				errs = append(errs, &RuleError{
-					Message: ev.Error(),
-					Code:    r.errorCode,
-				})
+		err := r.rules[i].Validate(v)
+		if err == nil {
+			continue
+		}
+		switch ev := err.(type) {
+		case *RuleError:
+			errs = append(errs, ev.AddCode(r.errorCode))
+		case *PropertyError:
+			for _, e := range ev.Errors {
+				_ = e.AddCode(r.errorCode)
 			}
+			errs = append(errs, ev)
+		default:
+			errs = append(errs, &RuleError{
+				Message: ev.Error(),
+				Code:    r.errorCode,
+			})
+		}
+		if r.mode == CascadeModeStop {
+			break
 		}
 	}
 	if len(errs) > 0 {
@@ -58,6 +65,13 @@ func (r RuleSet[T]) Validate(v T) error {
 // WithErrorCode sets the error code for each returned [RuleError].
 func (r RuleSet[T]) WithErrorCode(code ErrorCode) RuleSet[T] {
 	r.errorCode = code
+	return r
+}
+
+// Cascade sets the [CascadeMode] for the rule set,
+// which controls the flow of evaluating the validation rules.
+func (r RuleSet[T]) Cascade(mode CascadeMode) RuleSet[T] {
+	r.mode = mode
 	return r
 }
 


### PR DESCRIPTION
## Motivation

It would be useful to control how rules which are part of a rule set are evaluated.
Since we already have the concept of cascade mode present, we can easily reuse it.

One common example of where that would be beneficial are regular expressions which
have general length conditions.
Instead of packing up the regular expression with `{len}`, we could instead define two rules within a rule set.

## Release Notes

Added advanced rules' evaluation control to `govy.RuleSet` through `govy.RuleSet.Cascade()` method.
If `govy.CascadeModeStop` is used the rule set will stop evaluating further rules once a first error is encountered.
The behavior is consistent with `govy.PropertyRules.Cascade`.
