### PR TITLE
chore: Switch StringDNSLabel to RuleSet

### DIFF
--- a/docs/validator-comparison/example_test.go
+++ b/docs/validator-comparison/example_test.go
@@ -226,9 +226,9 @@ func Example_govy() {
 	//   - 'kind' with value 'Project':
 	//     - should be equal to 'Service'
 	//   - 'metadata.name' with value 'slo-status api':
-	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 	//   - 'metadata.project' with value 'default project':
-	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 	//   - 'metadata.labels.ke y' with key 'ke y':
 	//     - string must match regular expression: '^\p{Ll}([_\-0-9\p{Ll}]*[0-9\p{Ll}])?$'
 }

--- a/pkg/govy/error_code.go
+++ b/pkg/govy/error_code.go
@@ -7,3 +7,7 @@ type ErrorCode = string
 const (
 	ErrorCodeTransform ErrorCode = "transform"
 )
+
+func addErrorCode(c1, c2 ErrorCode) ErrorCode {
+	return concatStrings(c1, c2, ErrorCodeSeparator)
+}

--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -230,7 +230,7 @@ func (r *RuleError) Error() string {
 //
 // This will result in 'last:another:code' [ErrorCode].
 func (r *RuleError) AddCode(code ErrorCode) *RuleError {
-	r.Code = concatStrings(code, r.Code, ErrorCodeSeparator)
+	r.Code = addErrorCode(code, r.Code)
 	return r
 }
 

--- a/pkg/govy/rule_set.go
+++ b/pkg/govy/rule_set.go
@@ -15,16 +15,14 @@ func RuleSetToPointer[T any](ruleSet RuleSet[T]) RuleSet[*T] {
 		rules = append(rules, RuleToPointer(rule))
 	}
 	return RuleSet[*T]{
-		rules:     rules,
-		errorCode: ruleSet.errorCode,
+		rules: rules,
 	}
 }
 
 // RuleSet allows defining a [Rule] which aggregates multiple sub-rules.
 type RuleSet[T any] struct {
-	rules     []Rule[T]
-	errorCode ErrorCode
-	mode      CascadeMode
+	rules []Rule[T]
+	mode  CascadeMode
 }
 
 // Validate works the same way as [Rule.Validate],
@@ -39,17 +37,11 @@ func (r RuleSet[T]) Validate(v T) error {
 			continue
 		}
 		switch ev := err.(type) {
-		case *RuleError:
-			errs = append(errs, ev.AddCode(r.errorCode))
-		case *PropertyError:
-			for _, e := range ev.Errors {
-				_ = e.AddCode(r.errorCode)
-			}
+		case *RuleError, *PropertyError:
 			errs = append(errs, ev)
 		default:
 			errs = append(errs, &RuleError{
 				Message: ev.Error(),
-				Code:    r.errorCode,
 			})
 		}
 		if r.mode == CascadeModeStop {
@@ -64,7 +56,9 @@ func (r RuleSet[T]) Validate(v T) error {
 
 // WithErrorCode sets the error code for each returned [RuleError].
 func (r RuleSet[T]) WithErrorCode(code ErrorCode) RuleSet[T] {
-	r.errorCode = code
+	for i := range r.rules {
+		r.rules[i].errorCode = addErrorCode(code, r.rules[i].errorCode)
+	}
 	return r
 }
 

--- a/pkg/govy/test_data/expected_pod_plan.json
+++ b/pkg/govy/test_data/expected_pod_plan.json
@@ -68,9 +68,13 @@
       "type": "string",
       "rules": [
         {
-          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$'",
+          "description": "length must be between 1 and 63",
+          "errorCode": "string_dns_label:string_length"
+        },
+        {
+          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'",
           "details": "an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character",
-          "errorCode": "string_dns_label",
+          "errorCode": "string_dns_label:string_match_regexp",
           "examples": [
             "my-name",
             "123-abc"
@@ -143,9 +147,13 @@
       "type": "string",
       "rules": [
         {
-          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$'",
+          "description": "length must be between 1 and 63",
+          "errorCode": "string_dns_label:string_length"
+        },
+        {
+          "description": "string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'",
           "details": "an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character",
-          "errorCode": "string_dns_label",
+          "errorCode": "string_dns_label:string_match_regexp",
           "examples": [
             "my-name",
             "123-abc"

--- a/pkg/rules/regex.go
+++ b/pkg/rules/regex.go
@@ -12,7 +12,7 @@ var (
 	uuidRegexp  = lazyRegexCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 	asciiRegexp = lazyRegexCompile(`^[\x00-\x7F]*$`)
 	// Ref: https://www.ietf.org/rfc/rfc1123.txt
-	rfc1123DnsLabelRegexp     = lazyRegexCompile("^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$")
+	rfc1123DnsLabelRegexp     = lazyRegexCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 	alphaRegexp               = lazyRegexCompile("^[a-zA-Z]*$")
 	alphanumericRegexp        = lazyRegexCompile("^[a-zA-Z0-9]*$")
 	alphaUnicodeRegexp        = lazyRegexCompile("^[\\p{L}]*$")

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -79,12 +79,16 @@ func StringDenyRegexp(re *regexp.Regexp) govy.Rule[string] {
 }
 
 // StringDNSLabel ensures the property's value is a valid DNS label as defined by RFC 1123.
-func StringDNSLabel() govy.Rule[string] {
-	return StringMatchRegexp(rfc1123DnsLabelRegexp()).
-		WithDetails("an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-',"+
-			" and must start and end with an alphanumeric character").
-		WithExamples("my-name", "123-abc").
-		WithErrorCode(ErrorCodeStringDNSLabel)
+func StringDNSLabel() govy.RuleSet[string] {
+	return govy.NewRuleSet(
+		StringLength(1, 63),
+		StringMatchRegexp(rfc1123DnsLabelRegexp()).
+			WithDetails("an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-',"+
+				" and must start and end with an alphanumeric character").
+			WithExamples("my-name", "123-abc"),
+	).
+		WithErrorCode(ErrorCodeStringDNSLabel).
+		Cascade(govy.CascadeModeStop)
 }
 
 // StringEmail ensures the property's value is a valid email address.


### PR DESCRIPTION
## Motivation

This PR is a follow up on https://github.com/nobl9/govy/pull/81.
It uses the features introduced there which make `govy.RuleSet` a suitable solution for complex regular expressions where we can separate some of the requirements, like string length into separate `govy.Rule`.

## Breaking Changes

`rules.StringDNSLabel` is no longer a `govy.Rule` but rather a `govy.RuleSet`. The rule set now consists of two rules, one for string length and one for the regular expression. This means both the `govy.Plan` and produced `govy.RuleError.ErrorCode` have changed.
