### PR TITLE
feat: Add type kind to validation plan and refactor type info

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,10 @@ func Example_validationPlan() {
 	//   "properties": [
 	//     {
 	//       "path": "$.middleName",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "isOptional": true,
 	//       "rules": [
 	//         {
@@ -569,7 +572,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.name",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "string cannot be empty",
@@ -583,8 +589,11 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.students",
-	//       "type": "[]Student",
-	//       "package": "github.com/nobl9/govy/internal/examples",
+	//       "typeInfo": {
+	//         "name": "[]Student",
+	//         "kind": "[]struct",
+	//         "package": "github.com/nobl9/govy/internal/examples"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "length must be less than or equal to 2",
@@ -598,7 +607,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.students[*].index",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "length must be between 9 and 9",
@@ -608,7 +620,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.university.address",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "string must match regular expression: '[\\w\\s.]+, [0-9]{2}-[0-9]{3} \\w+'",
@@ -626,7 +641,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.university.name",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "",

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -47,6 +47,7 @@ words:
   - govyconfig
   - govytest
   - ldflags
+  - mypkg
   - nobl
   - pkgs
   - println

--- a/internal/examples/readme_validation_plan_example_test.go
+++ b/internal/examples/readme_validation_plan_example_test.go
@@ -81,7 +81,10 @@ func Example_validationPlan() {
 	//   "properties": [
 	//     {
 	//       "path": "$.middleName",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "isOptional": true,
 	//       "rules": [
 	//         {
@@ -92,7 +95,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.name",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "string cannot be empty",
@@ -106,8 +112,11 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.students",
-	//       "type": "[]Student",
-	//       "package": "github.com/nobl9/govy/internal/examples",
+	//       "typeInfo": {
+	//         "name": "[]Student",
+	//         "kind": "[]struct",
+	//         "package": "github.com/nobl9/govy/internal/examples"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "length must be less than or equal to 2",
@@ -121,7 +130,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.students[*].index",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "length must be between 9 and 9",
@@ -131,7 +143,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.university.address",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "string must match regular expression: '[\\w\\s.]+, [0-9]{2}-[0-9]{3} \\w+'",
@@ -149,7 +164,10 @@ func Example_validationPlan() {
 	//     },
 	//     {
 	//       "path": "$.university.name",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "rules": [
 	//         {
 	//           "description": "",

--- a/internal/typeinfo/type_info.go
+++ b/internal/typeinfo/type_info.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 )
 
-// TypeInfo stores the type information.
+// TypeInfo stores the Go type information.
 type TypeInfo struct {
 	Name    string
-	Package string
 	Kind    string
+	Package string
 }
 
 // Get returns the information for the type T.
@@ -18,7 +18,7 @@ type TypeInfo struct {
 // Package is only available if the type is not a built-in type.
 //
 // It has a special treatment for slices of type definitions.
-// Istead of having:
+// Instead of having:
 //
 //	TypeInfo{Name: "[]mypkg.Bar"}
 //

--- a/internal/typeinfo/type_info.go
+++ b/internal/typeinfo/type_info.go
@@ -1,0 +1,63 @@
+package typeinfo
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// TypeInfo stores the type information.
+type TypeInfo struct {
+	Name    string
+	Package string
+	Kind    string
+}
+
+// Get returns the information for the type T.
+// It returns the type name without package path or name.
+// It strips the pointer '*' from the type name.
+// Package is only available if the type is not a built-in type.
+//
+// It has a special treatment for slices of type definitions.
+// Istead of having:
+//
+//	TypeInfo{Name: "[]mypkg.Bar"}
+//
+// It will produce:
+//
+//	TypeInfo{Name: "[]Bar", Package: ".../mypkg"}.
+func Get[T any]() TypeInfo {
+	typ := reflect.TypeOf(*new(T))
+	if typ == nil {
+		return TypeInfo{}
+	}
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	result := TypeInfo{
+		Kind: getKindString(typ),
+	}
+
+	if typ.PkgPath() == "" && typ.Kind() == reflect.Slice {
+		result.Name = "[]"
+		typ = typ.Elem()
+	}
+	switch {
+	case typ.PkgPath() == "":
+		result.Name += typ.String()
+	default:
+		result.Name += typ.Name()
+		result.Package = typ.PkgPath()
+	}
+	return result
+}
+
+func getKindString(typ reflect.Type) string {
+	switch typ.Kind() {
+	case reflect.Map:
+		return fmt.Sprintf("map[%s]%s", getKindString(typ.Key()), getKindString(typ.Elem()))
+	case reflect.Slice:
+		return fmt.Sprintf("[]%s", getKindString(typ.Elem()))
+	default:
+		return typ.Kind().String()
+	}
+}

--- a/internal/typeinfo/type_info_test.go
+++ b/internal/typeinfo/type_info_test.go
@@ -1,0 +1,92 @@
+package typeinfo
+
+import (
+	"testing"
+
+	"github.com/nobl9/govy/internal/assert"
+)
+
+const packageName = "github.com/nobl9/govy/internal/typeinfo"
+
+type customString string
+
+type customStruct struct{}
+
+type customMap map[string]int
+
+type customList []customMap
+
+type customNestedMap map[customString]customList
+
+type testCase struct {
+	name     string
+	typeFunc func() TypeInfo
+	expected TypeInfo
+}
+
+func TestGet(t *testing.T) {
+	tests := []testCase{
+		{
+			name:     "int",
+			typeFunc: func() TypeInfo { return Get[int]() },
+			expected: TypeInfo{Name: "int", Package: "", Kind: "int"},
+		},
+		{
+			name:     "pointer to int",
+			typeFunc: func() TypeInfo { return Get[*int]() },
+			expected: TypeInfo{Name: "int", Package: "", Kind: "int"},
+		},
+		{
+			name:     "slice of int",
+			typeFunc: func() TypeInfo { return Get[[]int]() },
+			expected: TypeInfo{Name: "[]int", Package: "", Kind: "[]int"},
+		},
+		{
+			name:     "slice of customString",
+			typeFunc: func() TypeInfo { return Get[[]customString]() },
+			expected: TypeInfo{Name: "[]customString", Package: packageName, Kind: "[]string"},
+		},
+		{
+			name:     "map of string to int",
+			typeFunc: func() TypeInfo { return Get[map[string]int]() },
+			expected: TypeInfo{Name: "map[string]int", Package: "", Kind: "map[string]int"},
+		},
+		{
+			name:     "custom string",
+			typeFunc: func() TypeInfo { return Get[customString]() },
+			expected: TypeInfo{Name: "customString", Package: packageName, Kind: "string"},
+		},
+		{
+			name:     "custom struct",
+			typeFunc: func() TypeInfo { return Get[customStruct]() },
+			expected: TypeInfo{Name: "customStruct", Package: packageName, Kind: "struct"},
+		},
+		{
+			name:     "pointer to custom struct",
+			typeFunc: func() TypeInfo { return Get[*customStruct]() },
+			expected: TypeInfo{Name: "customStruct", Package: packageName, Kind: "struct"},
+		},
+		{
+			name:     "custom map",
+			typeFunc: func() TypeInfo { return Get[customMap]() },
+			expected: TypeInfo{Name: "customMap", Package: packageName, Kind: "map[string]int"},
+		},
+		{
+			name:     "custom nested map",
+			typeFunc: func() TypeInfo { return Get[customNestedMap]() },
+			expected: TypeInfo{Name: "customNestedMap", Package: packageName, Kind: "map[string][]map[string]int"},
+		},
+		{
+			name:     "custom list",
+			typeFunc: func() TypeInfo { return Get[customList]() },
+			expected: TypeInfo{Name: "customList", Package: packageName, Kind: "[]map[string]int"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.typeFunc()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -1710,7 +1710,10 @@ func ExamplePlan() {
 	//   "properties": [
 	//     {
 	//       "path": "$.name",
-	//       "type": "string",
+	//       "typeInfo": {
+	//         "name": "string",
+	//         "kind": "string"
+	//       },
 	//       "examples": [
 	//         "Jake",
 	//         "John"

--- a/pkg/govy/plan.go
+++ b/pkg/govy/plan.go
@@ -1,7 +1,6 @@
 package govy
 
 import (
-	"reflect"
 	"sort"
 	"strings"
 
@@ -20,6 +19,9 @@ type PropertyPlan struct {
 	Path string `json:"path"`
 	// Type is a Go type name of the property.
 	Type string `json:"type"`
+	// Kind is a Go type kind of the property.
+	// Example: "string", "int", "bool", "struct", "slice", etc.
+	Kind string `json:"kind"`
 	// Package is the full package path of the Type.
 	Package string `json:"package,omitempty"`
 	// IsOptional indicates if the property was marked with [PropertyRules.OmitEmpty].
@@ -61,6 +63,7 @@ func Plan[S any](v Validator[S]) *ValidatorPlan {
 			entry = PropertyPlan{
 				Path:       p.path,
 				Type:       p.propertyPlan.Type,
+				Kind:       p.propertyPlan.Kind,
 				Package:    p.propertyPlan.Package,
 				Examples:   p.propertyPlan.Examples,
 				IsOptional: p.propertyPlan.IsOptional,
@@ -119,36 +122,4 @@ func (p planBuilder) appendPath(path string) planBuilder {
 func (p planBuilder) setExamples(examples ...string) planBuilder {
 	p.propertyPlan.Examples = examples
 	return p
-}
-
-// typeInfo stores the type name and its package if it's available.
-type typeInfo struct {
-	Name    string
-	Package string
-}
-
-// getTypeInfo returns the information for the type T.
-// It returns the type name without package path or name.
-// It strips the pointer '*' from the type name.
-// Package is only available if the type is not a built-in type.
-func getTypeInfo[T any]() typeInfo {
-	typ := reflect.TypeOf(*new(T))
-	if typ == nil {
-		return typeInfo{}
-	}
-	var result typeInfo
-	if typ.Kind() == reflect.Ptr {
-		typ = typ.Elem()
-	}
-	if typ.Kind() == reflect.Slice {
-		typ = typ.Elem()
-		result.Name = "[]"
-	}
-	if typ.PkgPath() == "" {
-		result.Name += typ.String()
-	} else {
-		result.Name += typ.Name()
-		result.Package = typ.PkgPath()
-	}
-	return result
 }

--- a/pkg/govy/plan.go
+++ b/pkg/govy/plan.go
@@ -17,19 +17,28 @@ type ValidatorPlan struct {
 type PropertyPlan struct {
 	// Path is a JSON path to the property.
 	Path string `json:"path"`
-	// Type is a Go type name of the property.
-	Type string `json:"type"`
-	// Kind is a Go type kind of the property.
-	// Example: "string", "int", "bool", "struct", "slice", etc.
-	Kind string `json:"kind"`
-	// Package is the full package path of the Type.
-	Package string `json:"package,omitempty"`
+	// TypeInfo contains the type information of the property.
+	TypeInfo TypeInfo `json:"typeInfo"`
 	// IsOptional indicates if the property was marked with [PropertyRules.OmitEmpty].
 	IsOptional bool `json:"isOptional,omitempty"`
 	// IsHidden indicates if the property was marked with [PropertyRules.HideValue].
 	IsHidden bool       `json:"isHidden,omitempty"`
 	Examples []string   `json:"examples,omitempty"`
 	Rules    []RulePlan `json:"rules,omitempty"`
+}
+
+// TypeInfo contains the type information of a property.
+type TypeInfo struct {
+	// Name is a Go type name.
+	// Example: "Pod", "string", "int", "bool", etc.
+	Name string `json:"name"`
+	// Kind is a Go type kind.
+	// Example: "string", "int", "bool", "struct", "slice", etc.
+	Kind string `json:"kind"`
+	// Package is the full package path of the type.
+	// It's empty for builtin types.
+	// Example: "github.com/nobl9/govy/pkg/govy", "time", etc.
+	Package string `json:"package,omitempty"`
 }
 
 // RulePlan is a validation plan for a single [Rule].
@@ -62,9 +71,7 @@ func Plan[S any](v Validator[S]) *ValidatorPlan {
 		} else {
 			entry = PropertyPlan{
 				Path:       p.path,
-				Type:       p.propertyPlan.Type,
-				Kind:       p.propertyPlan.Kind,
-				Package:    p.propertyPlan.Package,
+				TypeInfo:   p.propertyPlan.TypeInfo,
 				Examples:   p.propertyPlan.Examples,
 				IsOptional: p.propertyPlan.IsOptional,
 				IsHidden:   p.propertyPlan.IsHidden,

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -233,14 +233,9 @@ func (r PropertyRules[T, S]) plan(builder planBuilder) {
 		builder.rulePlan.Conditions = append(builder.rulePlan.Conditions, predicate.description)
 	}
 	if r.originalType != nil {
-		builder.propertyPlan.Type = r.originalType.Name
-		builder.propertyPlan.Kind = r.originalType.Kind
-		builder.propertyPlan.Package = r.originalType.Package
+		builder.propertyPlan.TypeInfo = TypeInfo(*r.originalType)
 	} else {
-		typInfo := typeinfo.Get[T]()
-		builder.propertyPlan.Type = typInfo.Name
-		builder.propertyPlan.Kind = typInfo.Kind
-		builder.propertyPlan.Package = typInfo.Package
+		builder.propertyPlan.TypeInfo = TypeInfo(typeinfo.Get[T]())
 	}
 	builder = builder.appendPath(r.name).setExamples(r.examples...)
 	for _, rule := range r.rules {

--- a/pkg/govy/test_data/expected_pod_plan.json
+++ b/pkg/govy/test_data/expected_pod_plan.json
@@ -3,7 +3,10 @@
   "properties": [
     {
       "path": "$.apiVersion",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "must be one of: v1, v2",
@@ -13,7 +16,10 @@
     },
     {
       "path": "$.kind",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "should be equal to 'Pod'",
@@ -23,8 +29,11 @@
     },
     {
       "path": "$.metadata.annotations",
-      "type": "Annotations",
-      "package": "github.com/nobl9/govy/pkg/govy_test",
+      "typeInfo": {
+        "name": "Annotations",
+        "kind": "map[string]string",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      },
       "rules": [
         {
           "description": "length must be less than or equal to 10",
@@ -34,8 +43,11 @@
     },
     {
       "path": "$.metadata.annotations.*",
-      "type": "MapItem[string,string]",
-      "package": "github.com/nobl9/govy/pkg/govy",
+      "typeInfo": {
+        "name": "MapItem[string,string]",
+        "kind": "struct",
+        "package": "github.com/nobl9/govy/pkg/govy"
+      },
       "rules": [
         {
           "description": "key and value must not be equal"
@@ -44,8 +56,11 @@
     },
     {
       "path": "$.metadata.labels",
-      "type": "Labels",
-      "package": "github.com/nobl9/govy/pkg/govy_test",
+      "typeInfo": {
+        "name": "Labels",
+        "kind": "map[string]string",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      },
       "rules": [
         {
           "description": "length must be less than or equal to 10",
@@ -55,7 +70,10 @@
     },
     {
       "path": "$.metadata.labels.*",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "length must be less than or equal to 120",
@@ -65,7 +83,10 @@
     },
     {
       "path": "$.metadata.labels.~",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "length must be between 1 and 63",
@@ -84,7 +105,10 @@
     },
     {
       "path": "$.metadata.name",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "string cannot be empty",
@@ -94,7 +118,10 @@
     },
     {
       "path": "$.metadata.namespace",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "string cannot be empty",
@@ -104,8 +131,11 @@
     },
     {
       "path": "$.spec.containers",
-      "type": "[]Container",
-      "package": "github.com/nobl9/govy/pkg/govy_test",
+      "typeInfo": {
+        "name": "[]Container",
+        "kind": "[]struct",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      },
       "rules": [
         {
           "description": "length must be less than or equal to 10",
@@ -119,13 +149,19 @@
     },
     {
       "path": "$.spec.containers[*].env",
-      "type": "[]EnvVar",
-      "package": "github.com/nobl9/govy/pkg/govy_test"
+      "typeInfo": {
+        "name": "[]EnvVar",
+        "kind": "[]struct",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      }
     },
     {
       "path": "$.spec.containers[*].env[*]",
-      "type": "EnvVar",
-      "package": "github.com/nobl9/govy/pkg/govy_test",
+      "typeInfo": {
+        "name": "EnvVar",
+        "kind": "struct",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      },
       "rules": [
         {
           "description": "custom error!"
@@ -134,7 +170,10 @@
     },
     {
       "path": "$.spec.containers[*].image",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "string cannot be empty",
@@ -144,7 +183,10 @@
     },
     {
       "path": "$.spec.containers[*].name",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "length must be between 1 and 63",
@@ -163,7 +205,10 @@
     },
     {
       "path": "$.spec.dnsPolicy",
-      "type": "string",
+      "typeInfo": {
+        "name": "string",
+        "kind": "string"
+      },
       "rules": [
         {
           "description": "must be one of: ClusterFirst, Default",


### PR DESCRIPTION
## Release Notes

Added type kind to validation plan, on top of existing type name and optional package (for non-native types).
Example: `{"name": "[]Student", "kind": "[]struct", "package": "github.com/me/mylib/pkg/mypkg"}`.

## Breaking Changes

Validation plan fields `type` and `package` has been moved to `typeInfo` object and `type` has bee renamed to `name`.