### PR TITLE
chore: Improve error message

### DIFF
--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -173,7 +173,11 @@ func assertValidatorError(t testingT, err error) (*govy.ValidatorError, bool) {
 	}
 	validatorErr, ok := err.(*govy.ValidatorError)
 	if !ok {
-    t.Errorf("Input error should be of type %[1]T, but was of type %[2]T.\nError: %[2]v", &govy.ValidatorError{}, err)
+		t.Errorf(
+			"Input error should be of type %[1]T, but was of type %[2]T.\nError: %[2]v",
+			&govy.ValidatorError{},
+			err,
+		)
 	}
 	return validatorErr, ok
 }

--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -173,7 +173,7 @@ func assertValidatorError(t testingT, err error) (*govy.ValidatorError, bool) {
 	}
 	validatorErr, ok := err.(*govy.ValidatorError)
 	if !ok {
-		t.Errorf("Input error should be of type %T.", &govy.ValidatorError{})
+    t.Errorf("Input error should be of type %[1]T, but was of type %[2]T.\nError: %[2]v", &govy.ValidatorError{}, err)
 	}
 	return validatorErr, ok
 }

--- a/pkg/govytest/assert_test.go
+++ b/pkg/govytest/assert_test.go
@@ -61,7 +61,8 @@ func TestAssertError(t *testing.T) {
 			ok:             false,
 			inputError:     errors.New("foo!"),
 			expectedErrors: []govytest.ExpectedRuleError{{PropertyName: "this", Message: "test"}},
-      out:            "Input error should be of type *govy.ValidatorError, but was of type *errors.errorString.\nError: foo!",
+			out: "Input error should be of type *govy.ValidatorError," +
+				" but was of type *errors.errorString.\nError: foo!",
 		},
 		"errors count mismatch": {
 			ok: false,
@@ -368,9 +369,10 @@ func TestAssertErrorContains(t *testing.T) {
 		},
 		"wrong type of error": {
 			ok:            false,
-			inputError:    errors.New(""),
+			inputError:    errors.New("foo!"),
 			expectedError: govytest.ExpectedRuleError{PropertyName: "this", Message: "test"},
-			out:           "Input error should be of type *govy.ValidatorError.",
+			out: "Input error should be of type *govy.ValidatorError," +
+				" but was of type *errors.errorString.\nError: foo!",
 		},
 		"no matches": {
 			ok: false,

--- a/pkg/govytest/assert_test.go
+++ b/pkg/govytest/assert_test.go
@@ -59,9 +59,9 @@ func TestAssertError(t *testing.T) {
 		},
 		"wrong type of error": {
 			ok:             false,
-			inputError:     errors.New(""),
+			inputError:     errors.New("foo!"),
 			expectedErrors: []govytest.ExpectedRuleError{{PropertyName: "this", Message: "test"}},
-			out:            "Input error should be of type *govy.ValidatorError.",
+      out:            "Input error should be of type *govy.ValidatorError, but was of type *errors.errorString.\nError: foo!",
 		},
 		"errors count mismatch": {
 			ok: false,


### PR DESCRIPTION
## Motivation

Currently `govytest.AsserError` when handling a type other than `*govy.ValidatorError` fails assertion with a non-descriptive error message.
This PR extends the error details of that assertion.
