### PR TITLE
feat: Extend govytest assertions with govy.ValidatorErrors

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Fail fails the test with the provided message.
-func Fail(t testing.TB, msg string, a ...interface{}) bool {
+func Fail(t testing.TB, msg string, a ...any) bool {
 	t.Helper()
 	t.Errorf(msg, a...)
 	return false
@@ -26,7 +26,7 @@ func Require(t testing.TB, isPassing bool) {
 }
 
 // Equal fails the test if the expected and actual values are not equal.
-func Equal(t testing.TB, expected, actual interface{}) bool {
+func Equal(t testing.TB, expected, actual any) bool {
 	t.Helper()
 	if !areEqual(expected, actual) {
 		return Fail(t, "Expected: %v\nActual: %v", expected, actual)
@@ -53,7 +53,7 @@ func False(t testing.TB, actual bool) bool {
 }
 
 // Len fails the test if the object is not of the expected length.
-func Len(t testing.TB, object interface{}, length int) bool {
+func Len(t testing.TB, object any, length int) bool {
 	t.Helper()
 	if actual := getLen(object); actual != length {
 		return Fail(t, "Expected length: %d\nActual: %d", length, actual)
@@ -63,7 +63,7 @@ func Len(t testing.TB, object interface{}, length int) bool {
 
 // IsType fails the test if the object is not of the expected type.
 // The expected type is specified using a type parameter.
-func IsType[T any](t testing.TB, object interface{}) bool {
+func IsType[T any](t testing.TB, object any) bool {
 	t.Helper()
 	switch object.(type) {
 	case T:
@@ -164,7 +164,7 @@ func Panic(t testing.TB, f func(), expected string) (result bool) {
 	return false
 }
 
-func areEqual(expected, actual interface{}) bool {
+func areEqual(expected, actual any) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
 	}
@@ -174,7 +174,7 @@ func areEqual(expected, actual interface{}) bool {
 	return true
 }
 
-func getLen(v interface{}) int {
+func getLen(v any) int {
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
 	case reflect.Slice, reflect.Map, reflect.String:

--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -2,7 +2,10 @@ package govytest
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/nobl9/govy/pkg/govy"
 	"github.com/nobl9/govy/pkg/rules"
@@ -20,7 +23,7 @@ type testingT interface {
 // Its fields are used to find and match an actual [govy.RuleError].
 type ExpectedRuleError struct {
 	// Optional. Matched against [govy.PropertyError.PropertyName].
-	// It should be only left empty if the validate property has no name.
+	// It should be only left empty if the validated property has no name.
 	PropertyName string `json:"propertyName"`
 	// Optional. Matched against [govy.RuleError.Code].
 	Code govy.ErrorCode `json:"code,omitempty"`
@@ -30,6 +33,11 @@ type ExpectedRuleError struct {
 	ContainsMessage string `json:"containsMessage,omitempty"`
 	// Optional. Matched against [govy.PropertyError.IsKeyError].
 	IsKeyError bool `json:"isKeyError,omitempty"`
+
+	// Optional. Matched against [govy.ValidatorError.Name].
+	ValidatorName string `json:"validatorName,omitempty"`
+	// Optional. Matched against [govy.ValidatorError.SliceIndex].
+	ValidatorIndex *int `json:"validatorIndex,omitempty"`
 }
 
 // expectedRuleErrorValidation defines the validation rules for [ExpectedRuleError].
@@ -42,10 +50,25 @@ var expectedRuleErrorValidation = govy.New(
 		})),
 ).InferName()
 
-// Validate checks if the [ExpectedRuleError] is valid.
-func (e ExpectedRuleError) Validate() error {
-	return expectedRuleErrorValidation.Validate(e)
-}
+// expectedRuleErrorValidationForValidatorErrors defines the validation rules for [ExpectedRuleError]
+// when asserting errors in [govy.ValidatorErrors] slice.
+var expectedRuleErrorValidationForValidatorErrors = govy.New(
+	govy.For(govy.GetSelf[ExpectedRuleError]()).
+		Rules(rules.OneOfProperties(map[string]func(e ExpectedRuleError) any{
+			"validatorName":  func(e ExpectedRuleError) any { return e.ValidatorName },
+			"validatorIndex": func(e ExpectedRuleError) any { return e.ValidatorIndex },
+		}).
+			WithDetails(fmt.Sprintf(
+				"\n  The actual error was of type %T."+
+					"\n  in order to match expected error with an actual error"+
+					" produced by a specific govy.Validator instance,"+
+					"\n  either the name of the validator, its index (when using ValidateSlice method) or both must be provided."+
+					"\n  Otherwise the tests might produce ambiguous results.",
+				govy.ValidatorErrors{},
+			))),
+	govy.ForPointer(func(e ExpectedRuleError) *int { return e.ValidatorIndex }).
+		Rules(rules.GTE(0)),
+).InferName()
 
 // AssertNoError asserts that the provided error is nil.
 // If the error is not nil and of type [govy.ValidatorError] it will try
@@ -128,13 +151,139 @@ func assertError(
 ) bool {
 	t.Helper()
 
-	if !validateExpectedErrors(t, expectedErrors...) {
+	if err == nil {
+		t.Errorf("Input error should not be nil.")
 		return false
 	}
-	validatorErr, ok := assertValidatorError(t, err)
-	if !ok {
+
+	if !validateExpectedErrors(t, countErrors, expectedErrors...) {
 		return false
 	}
+
+	switch v := err.(type) {
+	case *govy.ValidatorError:
+		return assertValidatorError(t, countErrors, v, expectedErrors)
+	case govy.ValidatorErrors:
+		return assertValidatorErrors(t, countErrors, v, expectedErrors)
+	default:
+		t.Errorf(
+			"Input error should be of type %[1]T or %[2]T, but was of type %[3]T.\nError: %[3]v",
+			&govy.ValidatorError{},
+			govy.ValidatorErrors{},
+			err,
+		)
+		return false
+	}
+}
+
+func validateExpectedErrors(t testingT, countErrors bool, expectedErrors ...ExpectedRuleError) bool {
+	t.Helper()
+	if len(expectedErrors) == 0 {
+		t.Errorf("%T must not be empty.", expectedErrors)
+		return false
+	}
+	switch countErrors {
+	case true:
+		if err := expectedRuleErrorValidation.ValidateSlice(expectedErrors); err != nil {
+			t.Error(err.Error())
+			return false
+		}
+	case false:
+		if err := expectedRuleErrorValidation.Validate(expectedErrors[0]); err != nil {
+			t.Error(err.Error())
+			return false
+		}
+	}
+	return true
+}
+
+func assertValidatorErrors(
+	t testingT,
+	countErrors bool,
+	validatorErrors govy.ValidatorErrors,
+	expectedErrors []ExpectedRuleError,
+) bool {
+	t.Helper()
+
+	if len(validatorErrors) == 0 {
+		t.Errorf("%T must not be empty.", validatorErrors)
+		return false
+	}
+
+	for _, expected := range expectedErrors {
+		if err := expectedRuleErrorValidationForValidatorErrors.Validate(expected); err != nil {
+			t.Error(err.Error())
+			return false
+		}
+	}
+
+	type validatorKey struct {
+		Name  string
+		Index int
+	}
+	validatorKeyFunc := func(name string, indexPtr *int) validatorKey {
+		index := -1
+		if indexPtr != nil {
+			index = *indexPtr
+		}
+		return validatorKey{name, index}
+	}
+
+	validators := make(map[validatorKey]*govy.ValidatorError, len(validatorErrors))
+	for _, err := range validatorErrors {
+		key := validatorKeyFunc(err.Name, err.SliceIndex)
+		if _, ok := validators[key]; ok {
+			t.Errorf("Multiple %T errors seem to originate from the same govy.Validator instance (%v).\n"+
+				"This will lead to ambiguous test results, as %T may be checked multiple times.",
+				govy.ValidatorErrors{}, key, ExpectedRuleError{})
+			return false
+		}
+		validators[key] = err
+	}
+
+	expectedErrorsPerValidator := make(map[validatorKey][]ExpectedRuleError)
+	for _, err := range expectedErrors {
+		key := validatorKeyFunc(err.ValidatorName, err.ValidatorIndex)
+		if _, ok := validators[key]; !ok {
+			t.Errorf("%T error was not matched")
+			return false
+		}
+		expectedErrorsPerValidator[key] = append(expectedErrorsPerValidator[key], err)
+	}
+
+	if len(expectedErrorsPerValidator) == 1 {
+		for k, v := range expectedErrorsPerValidator {
+			return assertError(t, countErrors, validators[k], v...)
+		}
+	}
+
+	passed := atomic.Bool{}
+	passed.Store(true)
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(validators))
+	for k, v := range expectedErrorsPerValidator {
+		go func() {
+			defer wg.Done()
+			ok := assertError(t, countErrors, validators[k], v...)
+			if !ok {
+				passed.Store(false)
+			}
+		}()
+	}
+	wg.Wait()
+
+	return passed.Load()
+}
+
+func assertValidatorError(
+	t testingT,
+	countErrors bool,
+	validatorErr *govy.ValidatorError,
+	expectedErrors []ExpectedRuleError,
+) bool {
+	t.Helper()
+
 	if countErrors {
 		if !assertErrorsCount(t, validatorErr, len(expectedErrors)) {
 			return false
@@ -147,39 +296,6 @@ func assertError(
 		}
 	}
 	return true
-}
-
-func validateExpectedErrors(t testingT, expectedErrors ...ExpectedRuleError) bool {
-	t.Helper()
-	if len(expectedErrors) == 0 {
-		t.Errorf("%T must not be empty.", expectedErrors)
-		return false
-	}
-	for _, expected := range expectedErrors {
-		if err := expected.Validate(); err != nil {
-			t.Error(err.Error())
-			return false
-		}
-	}
-	return true
-}
-
-func assertValidatorError(t testingT, err error) (*govy.ValidatorError, bool) {
-	t.Helper()
-
-	if err == nil {
-		t.Errorf("Input error should not be nil.")
-		return nil, false
-	}
-	validatorErr, ok := err.(*govy.ValidatorError)
-	if !ok {
-		t.Errorf(
-			"Input error should be of type %[1]T, but was of type %[2]T.\nError: %[2]v",
-			&govy.ValidatorError{},
-			err,
-		)
-	}
-	return validatorErr, ok
 }
 
 func assertErrorsCount(
@@ -254,7 +370,7 @@ func assertErrorMatches(
 	}
 
 	if multiMatch {
-		t.Errorf("Actual error was matched multiple times. Consider providing a more specific %T list.", expected)
+		t.Errorf("Actual error was matched multiple times. Provide a more specific %T list.", expected)
 		return false
 	}
 	encExpected, _ := json.MarshalIndent(expected, "", "  ")

--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -105,6 +105,13 @@ func AssertNoError(t testingT, err error) bool {
 // If [ExpectedRuleError.IsKeyError] is provided it will be required to match
 // the actual [govy.PropertyError.IsKeyError].
 //
+// If the actual error is of type [govy.ValidatorErrors] the following two fields are also matched:
+//   - [ExpectedRuleError.ValidatorName] is equal to [govy.ValidatorError.Name]
+//   - [ExpectedRuleError.ValidatorIndex] is equal to [govy.ValidatorError.SliceIndex]
+//
+// In the above case, all [ExpectedRuleError] are aggregated per matching [*govy.ValidatorError]
+// and the function runs for every aggregated validator recursively.
+//
 // It returns true if the error matches the expectations, false otherwise.
 func AssertError(
 	t testingT,
@@ -132,6 +139,10 @@ func AssertError(
 //
 // If [ExpectedRuleError.IsKeyError] is provided it will be required to match
 // the actual [govy.PropertyError.IsKeyError].
+//
+// If the actual error is of type [govy.ValidatorErrors] the following two fields are also matched:
+//   - [ExpectedRuleError.ValidatorName] is equal to [govy.ValidatorError.Name]
+//   - [ExpectedRuleError.ValidatorIndex] is equal to [govy.ValidatorError.SliceIndex]
 //
 // It returns true if the error matches the expectations, false otherwise.
 func AssertErrorContains(

--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -59,8 +59,8 @@ var expectedRuleErrorValidationForValidatorErrors = govy.New(
 			"validatorIndex": func(e ExpectedRuleError) any { return e.ValidatorIndex },
 		}).
 			WithDetails(fmt.Sprintf(
-				"\n  The actual error was of type %T."+
-					"\n  in order to match expected error with an actual error"+
+				"The actual error was of type %T."+
+					"\n  In order to match expected error with an actual error"+
 					" produced by a specific govy.Validator instance,"+
 					"\n  either the name of the validator, its index (when using ValidateSlice method) or both must be provided."+
 					"\n  Otherwise the tests might produce ambiguous results.",
@@ -249,7 +249,7 @@ func assertValidatorErrors(
 		key := validatorKeyFunc(err.ValidatorName, err.ValidatorIndex)
 		if _, ok := validators[key]; !ok {
 			t.Errorf("%[1]T did not match any of the %[2]T."+
-        "\n%[1]T must match one of the %[2]T by either (or both, if both were provided):"+
+				"\n%[1]T must match one of the %[2]T by either (or both, if both were provided):"+
 				"\n- %[1]T.ValidatorName == %[2]T.Name"+
 				"\n- %[1]T.ValidatorIndex == %[2]T.SliceIndex"+
 				"\nEXPECTED:\n%[3]s"+

--- a/pkg/govytest/assert_test.go
+++ b/pkg/govytest/assert_test.go
@@ -1,3 +1,4 @@
+// nolint: lll
 package govytest_test
 
 import (
@@ -374,9 +375,8 @@ func TestAssertError_ValidatorErrors(t *testing.T) {
 			inputError:     govy.ValidatorErrors{{}},
 			expectedErrors: []govytest.ExpectedRuleError{{Message: "foo"}},
 			out: `Validation for ExpectedRuleError has failed for the following properties:
-  - one of [validatorIndex, validatorName] properties must be set, none was provided; 
-    The actual error was of type govy.ValidatorErrors.
-    in order to match expected error with an actual error produced by a specific govy.Validator instance,
+  - one of [validatorIndex, validatorName] properties must be set, none was provided; The actual error was of type govy.ValidatorErrors.
+    In order to match expected error with an actual error produced by a specific govy.Validator instance,
     either the name of the validator, its index (when using ValidateSlice method) or both must be provided.
     Otherwise the tests might produce ambiguous results.`,
 		},

--- a/pkg/govytest/example_test.go
+++ b/pkg/govytest/example_test.go
@@ -183,7 +183,7 @@ func ExampleAssertError() {
 // You can set them both, but you need to provide at least one of them.
 //
 // Every [govytest.ExpectedRuleError] is aggregated per matched [govy.ValidatorError]
-// and the function runs recursively for every [govy.ValidatorError] and epxected errors pair.
+// and the function runs recursively for every [govy.ValidatorError] and expected errors pair.
 func ExampleAssertError_validatorErrors() {
 	teacherValidator := govy.New(
 		govy.For(func(t Teacher) string { return t.Name }).
@@ -212,7 +212,7 @@ func ExampleAssertError_validatorErrors() {
 		Name: "John",
 		University: University{
 			Name:    "Poznan University of Technology",
-			Address: "",
+			Address: "Some address",
 		},
 	}
 	teachers := []Teacher{teacherEve, teacherJohn}
@@ -241,25 +241,25 @@ func ExampleAssertError_validatorErrors() {
 
 	// Output:
 	// Expected error was not found.
-  // EXPECTED:
-  // {
-  //   "propertyName": "university.address",
-  //   "code": "greater_than",
-  //   "validatorName": "Eve",
-  //   "validatorIndex": 0
-  // }
-  // ACTUAL:
-  // [
-  //   {
-  //     "propertyName": "university.address",
-  //     "errors": [
-  //       {
-  //         "error": "property is required but was empty",
-  //         "code": "required"
-  //       }
-  //     ]
-  //   }
-  // ]
+	// EXPECTED:
+	// {
+	//   "propertyName": "university.address",
+	//   "code": "greater_than",
+	//   "validatorName": "Eve",
+	//   "validatorIndex": 0
+	// }
+	// ACTUAL:
+	// [
+	//   {
+	//     "propertyName": "university.address",
+	//     "errors": [
+	//       {
+	//         "error": "property is required but was empty",
+	//         "code": "required"
+	//       }
+	//     ]
+	//   }
+	// ]
 }
 
 // If you don't want to verify all the errors returned by [govy.Validator],


### PR DESCRIPTION
## Release Notes

`govytest.AssertError` and `govytest.AssertErrorContains` now both support `govy.ValidatorErrors` as an actual error input.
When expecting such an error two additional fields are provided in `govytest.ExpectedRuleError`: `ValidatorName` which matches `govy.ValidatorError.Name` and `ValidatorIndex` which matches `govy.ValidatorError.SliceIndex`.
