### PR TITLE
fix: Correct map keys handling (escape special characters)

### DIFF
--- a/docs/validator-comparison/example_test.go
+++ b/docs/validator-comparison/example_test.go
@@ -229,6 +229,6 @@ func Example_govy() {
 	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 	//   - 'metadata.project' with value 'default project':
 	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
-	//   - 'metadata.labels.ke y' with key 'ke y':
+	//   - 'metadata.labels.['ke y']' with key 'ke y':
 	//     - string must match regular expression: '^\p{Ll}([_\-0-9\p{Ll}]*[0-9\p{Ll}])?$'
 }

--- a/internal/jsonpath/doc.go
+++ b/internal/jsonpath/doc.go
@@ -1,0 +1,5 @@
+// Package jsonpath provides utilities for working with [JSONPath RFC-9535],
+// which is primarily used in govy for constructing property names.
+//
+// [JSONPath RFC-9535]: https://www.rfc-editor.org/rfc/rfc9535.html
+package jsonpath

--- a/internal/jsonpath/jsonpath.go
+++ b/internal/jsonpath/jsonpath.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	jsonPathSeparator = "."
-	escapedChars      = jsonPathSeparator + "[] \t\n"
+	escapedChars      = jsonPathSeparator + "[] \t\n\r"
 	slashEscapedChars = ""
 )
 

--- a/internal/jsonpath/jsonpath.go
+++ b/internal/jsonpath/jsonpath.go
@@ -1,0 +1,119 @@
+package jsonpath
+
+import (
+	"strconv"
+	"strings"
+)
+
+const (
+	jsonPathSeparator = "."
+	escapedChars      = jsonPathSeparator + "[] \t\n"
+	slashEscapedChars = ""
+)
+
+// EscapeSegment accepts a path segment (not the entire path!) and escapes any special characters.
+// Examples:
+//
+//	EscapeSegment("foo") --> "foo"
+//	EscapeSegment("'foo'") --> "\'foo\'"
+//	EscapeSegment("foo.bar") --> "['foo.bar']"
+func EscapeSegment(segment string) string {
+	shouldWrap := segment == "" || strings.ContainsAny(segment, escapedChars)
+	segment = escapeCharacters(segment)
+	if shouldWrap {
+		segment = "['" + segment + "']"
+	}
+	return segment
+}
+
+// Join extends the JSONPath with a new segment.
+// The segment can be a path in of itself, the segment is assumed to be escaped with [EscapeSegment].
+// Example:
+//
+//	Join("foo.bar", "baz") --> "foo.bar.baz"
+//	Join("foo.bar", "baz.foo") --> "foo.bar.baz.foo"
+func Join(path, segment string) string {
+	return joinPaths(path, segment, jsonPathSeparator)
+}
+
+// JoinArray extends the JSONPath with a new array segment.
+// Example:
+//
+//	JoinArray("foo.bar", "[2]") --> "foo.bar[2]"
+func JoinArray(path, segment string) string {
+	return joinPaths(path, segment, "")
+}
+
+// NewArrayIndex creates a new array index path segment for the given index.
+// Example:
+//
+//	NewArrayIndex(2) --> "[2]"
+func NewArrayIndex(index int) string {
+	return "[" + strconv.Itoa(index) + "]"
+}
+
+func joinPaths(pre, post, sep string) string {
+	if pre == "" {
+		return post
+	}
+	if post == "" {
+		return pre
+	}
+	return pre + sep + post
+}
+
+// escapeCharacters has been based on the [net/url] package.
+func escapeCharacters(s string) string {
+	escapedCount := 0
+	for i := range s {
+		if shouldEscape(s[i]) {
+			escapedCount++
+		}
+	}
+	if escapedCount == 0 {
+		return s
+	}
+
+	var buf [64]byte
+	var t []byte
+
+	required := len(s) + escapedCount
+	if required <= len(buf) {
+		t = buf[:required]
+	} else {
+		t = make([]byte, required)
+	}
+
+	j := 0
+	for i := range len(s) {
+		switch c := s[i]; {
+		case shouldEscape(c):
+			t[j] = '\\'
+			j++
+			switch c {
+			case '\n':
+				t[j] = 'n'
+			case '\t':
+				t[j] = 't'
+			case '\r':
+				t[j] = 'r'
+			default:
+				t[j] = c
+			}
+			j++
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}
+
+func shouldEscape(r byte) bool {
+	switch r {
+	case '\'', '\n', '\t', '\r':
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/jsonpath/jsonpath_test.go
+++ b/internal/jsonpath/jsonpath_test.go
@@ -1,0 +1,136 @@
+package jsonpath_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/nobl9/govy/internal/assert"
+	"github.com/nobl9/govy/internal/jsonpath"
+)
+
+func TestEscapeSegment(t *testing.T) {
+	tests := map[string]struct {
+		pathSegment string
+		expected    string
+	}{
+		"empty":                     {"", "['']"},
+		"not dots":                  {"foo", "foo"},
+		"one dot":                   {"foo.bar", "['foo.bar']"},
+		"two dots":                  {"foo.bar.baz", "['foo.bar.baz']"},
+		"single quote":              {"'foo", `\'foo`},
+		"single quotes":             {"'foo'", `\'foo\'`},
+		"fake escaped path":         {"['foo.bar']", `['[\'foo.bar\']']`},
+		"left bracket":              {"[foo", "['[foo']"},
+		"right bracket":             {"foo]", "['foo]']"},
+		"both brackets":             {"[foo]", "['[foo]']"},
+		"rackets":                   {"[foo.bar]", "['[foo.bar]']"},
+		"mixed brackets and quotes": {"'[foo]'", `['\'[foo]\'']`},
+		"single whitespace":         {"foo bar", "['foo bar']"},
+		"multiple whitespaces":      {"  foo.bar ", "['  foo.bar ']"},
+		"tab":                       {"\tfoo", "['\\tfoo']"},
+		"newline":                   {"\nfoo", "['\\nfoo']"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := jsonpath.EscapeSegment(tc.pathSegment)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestJoin(t *testing.T) {
+	tests := map[string]struct {
+		path     string
+		segment  string
+		expected string
+	}{
+		"empty path and segment": {
+			path:     "",
+			segment:  "",
+			expected: "",
+		},
+		"empty path": {
+			path:     "",
+			segment:  "foo",
+			expected: "foo",
+		},
+		"empty segment": {
+			path:     "foo",
+			segment:  "",
+			expected: "foo",
+		},
+		"path and segment": {
+			path:     "foo",
+			segment:  "bar",
+			expected: "foo.bar",
+		},
+		"path and segment path": {
+			path:     "foo",
+			segment:  "bar.baz",
+			expected: "foo.bar.baz",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := jsonpath.Join(tc.path, tc.segment)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestJoinArray(t *testing.T) {
+	tests := map[string]struct {
+		path     string
+		segment  string
+		expected string
+	}{
+		"empty path and segment": {
+			path:     "",
+			segment:  "",
+			expected: "",
+		},
+		"empty path": {
+			path:     "",
+			segment:  "[1]",
+			expected: "[1]",
+		},
+		"empty segment": {
+			path:     "foo",
+			segment:  "",
+			expected: "foo",
+		},
+		"path and segment": {
+			path:     "foo",
+			segment:  "[1]",
+			expected: "foo[1]",
+		},
+		"path and segment path": {
+			path:     "foo",
+			segment:  "[2].baz",
+			expected: "foo[2].baz",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := jsonpath.JoinArray(tc.path, tc.segment)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestNewArrayIndex(t *testing.T) {
+	tests := []struct {
+		index    int
+		expected string
+	}{
+		{0, "[0]"},
+		{1, "[1]"},
+		{10, "[10]"},
+	}
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual := jsonpath.NewArrayIndex(tc.index)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/internal/jsonpath/jsonpath_test.go
+++ b/internal/jsonpath/jsonpath_test.go
@@ -2,6 +2,7 @@ package jsonpath_test
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/nobl9/govy/internal/assert"
@@ -29,6 +30,8 @@ func TestEscapeSegment(t *testing.T) {
 		"multiple whitespaces":      {"  foo.bar ", "['  foo.bar ']"},
 		"tab":                       {"\tfoo", "['\\tfoo']"},
 		"newline":                   {"\nfoo", "['\\nfoo']"},
+		"carriage return":           {"\rfoo", "['\\rfoo']"},
+		"large string with escape":  {"\n" + strings.Repeat("l", 1000), "['\\n" + strings.Repeat("l", 1000) + "']"},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/govy/errors_internal_test.go
+++ b/pkg/govy/errors_internal_test.go
@@ -1,0 +1,60 @@
+package govy
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/nobl9/govy/internal/assert"
+)
+
+func TestPropertyError_prependPropertyName(t *testing.T) {
+	tests := []struct {
+		PropertyError *PropertyError
+		InputName     string
+		ExpectedName  string
+	}{
+		{
+			PropertyError: &PropertyError{},
+		},
+		{
+			PropertyError: &PropertyError{PropertyName: "test"},
+			ExpectedName:  "test",
+		},
+		{
+			PropertyError: &PropertyError{},
+			InputName:     "new",
+			ExpectedName:  "new",
+		},
+		{
+			PropertyError: &PropertyError{PropertyName: "original"},
+			InputName:     "added",
+			ExpectedName:  "added.original",
+		},
+		{
+			PropertyError: &PropertyError{PropertyName: "bar", IsSliceElementError: true},
+			InputName:     "foo[1]",
+			ExpectedName:  "foo[1].bar",
+		},
+		{
+			PropertyError: &PropertyError{PropertyName: "[2]", IsSliceElementError: true},
+			InputName:     "foo",
+			ExpectedName:  "foo[2]",
+		},
+		{
+			PropertyError: &PropertyError{PropertyName: "foo", IsSliceElementError: true},
+			InputName:     "[0]",
+			ExpectedName:  "[0].foo",
+		},
+		{
+			PropertyError: &PropertyError{PropertyName: "[1]", IsSliceElementError: true},
+			InputName:     "[0]",
+			ExpectedName:  "[0][1]",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tc.ExpectedName, tc.PropertyError.prependParentPropertyName(tc.InputName).PropertyName)
+		})
+	}
+}

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -129,10 +129,10 @@ func (r PropertyRules[T, S]) Validate(st S) error {
 		switch errValue := err.(type) {
 		// Same as Rule[S] as for GetSelf we'd get the same type on T and S.
 		case *PropertyError:
-			allErrors = append(allErrors, errValue.PrependParentPropertyName(r.name))
+			allErrors = append(allErrors, errValue.prependParentPropertyName(r.name))
 		case *ValidatorError:
 			for _, e := range errValue.Errors {
-				allErrors = append(allErrors, e.PrependParentPropertyName(r.name))
+				allErrors = append(allErrors, e.prependParentPropertyName(r.name))
 			}
 		default:
 			ruleErrors = append(ruleErrors, err)

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nobl9/govy/internal"
+	"github.com/nobl9/govy/internal/jsonpath"
 )
 
 // ForMap creates a new [PropertyRulesForMap] instance for a map property
@@ -60,7 +61,7 @@ func (r PropertyRulesForMap[M, K, V, S]) Validate(st S) error {
 			if keyErrors, ok := err.(PropertyErrors); ok {
 				for _, e := range keyErrors {
 					e.IsKeyError = true
-					propErrs = append(propErrs, e.PrependParentPropertyName(MapElementName(r.mapRules.name, k)))
+					propErrs = append(propErrs, e.prependParentPropertyName(r.getJSONPathForKey(k)))
 				}
 			} else {
 				logWrongErrorType(PropertyErrors{}, err)
@@ -69,7 +70,7 @@ func (r PropertyRulesForMap[M, K, V, S]) Validate(st S) error {
 		if err = r.forValueRules.Validate(v); err != nil {
 			if valueErrors, ok := err.(PropertyErrors); ok {
 				for _, e := range valueErrors {
-					propErrs = append(propErrs, e.PrependParentPropertyName(MapElementName(r.mapRules.name, k)))
+					propErrs = append(propErrs, e.prependParentPropertyName(r.getJSONPathForKey(k)))
 				}
 			} else {
 				logWrongErrorType(PropertyErrors{}, err)
@@ -81,7 +82,7 @@ func (r PropertyRulesForMap[M, K, V, S]) Validate(st S) error {
 					// TODO: Figure out how to handle custom PropertyErrors.
 					// Custom errors' value for nested item will be overridden by the actual value.
 					e.PropertyValue = internal.PropertyValueString(v)
-					propErrs = append(propErrs, e.PrependParentPropertyName(MapElementName(r.mapRules.name, k)))
+					propErrs = append(propErrs, e.prependParentPropertyName(r.getJSONPathForKey(k)))
 				}
 			} else {
 				logWrongErrorType(PropertyErrors{}, err)
@@ -206,10 +207,7 @@ func (r PropertyRulesForMap[M, K, V, S]) plan(builder planBuilder) {
 	}
 }
 
-// MapElementName generates a name for a map element denoted by its key.
-func MapElementName(mapName, key any) string {
-	if mapName == "" {
-		return fmt.Sprintf("%v", key)
-	}
-	return fmt.Sprintf("%s.%v", mapName, key)
+// getJSONPathForKey returns a JSONPath for the given key.
+func (r PropertyRulesForMap[M, K, V, S]) getJSONPathForKey(key any) string {
+	return jsonpath.Join(r.mapRules.name, jsonpath.EscapeSegment(fmt.Sprint(key)))
 }

--- a/pkg/govy/rules_for_map_test.go
+++ b/pkg/govy/rules_for_map_test.go
@@ -2,6 +2,7 @@ package govy_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/nobl9/govy/internal/assert"
@@ -129,13 +130,14 @@ func TestPropertyRulesForMap(t *testing.T) {
 
 		errs := mustPropertyErrors(t, r.Validate(mockStruct{StringMap: map[string]string{
 			"key1": "value1",
-			"key2": "value2",
+			"key 2": "value2",
 		}}))
 		assert.Require(t, assert.Len(t, errs, 12))
+    fmt.Println(errs)
 		assert.ElementsMatch(t, []*govy.PropertyError{
 			{
 				PropertyName:  "test.path",
-				PropertyValue: `{"key1":"value1","key2":"value2"}`,
+				PropertyValue: `{"key 2":"value2","key1":"value1"}`,
 				Errors:        []*govy.RuleError{{Message: errRule.Error()}},
 			},
 			{
@@ -145,8 +147,8 @@ func TestPropertyRulesForMap(t *testing.T) {
 				Errors:        []*govy.RuleError{{Message: errKey.Error()}},
 			},
 			{
-				PropertyName:  "test.path.key2",
-				PropertyValue: "key2",
+				PropertyName:  "test.path.['key 2']",
+				PropertyValue: "key 2",
 				IsKeyError:    true,
 				Errors:        []*govy.RuleError{{Message: errKey.Error()}},
 			},
@@ -157,7 +159,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 				Errors:        []*govy.RuleError{{Message: errNestedKey.Error()}},
 			},
 			{
-				PropertyName:  "test.path.key2.nested",
+				PropertyName:  "test.path.['key 2'].nested",
 				PropertyValue: "nestedKey",
 				IsKeyError:    true,
 				Errors:        []*govy.RuleError{{Message: errNestedKey.Error()}},
@@ -171,7 +173,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 				},
 			},
 			{
-				PropertyName:  "test.path.key2",
+				PropertyName:  "test.path.['key 2']",
 				PropertyValue: "value2",
 				Errors: []*govy.RuleError{
 					{Message: errValue.Error()},
@@ -184,7 +186,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 				Errors:        []*govy.RuleError{{Message: errNestedValue.Error()}},
 			},
 			{
-				PropertyName:  "test.path.key2.nested",
+				PropertyName:  "test.path.['key 2'].nested",
 				PropertyValue: "nestedValue",
 				Errors:        []*govy.RuleError{{Message: errNestedValue.Error()}},
 			},
@@ -194,7 +196,7 @@ func TestPropertyRulesForMap(t *testing.T) {
 				Errors:        []*govy.RuleError{{Message: errNestedItem.Error()}},
 			},
 			{
-				PropertyName:  "test.path.key2.nested",
+				PropertyName:  "test.path.['key 2'].nested",
 				PropertyValue: "value2",
 				Errors:        []*govy.RuleError{{Message: errNestedItem.Error()}},
 			},

--- a/pkg/govy/rules_for_map_test.go
+++ b/pkg/govy/rules_for_map_test.go
@@ -129,11 +129,11 @@ func TestPropertyRulesForMap(t *testing.T) {
 			}))
 
 		errs := mustPropertyErrors(t, r.Validate(mockStruct{StringMap: map[string]string{
-			"key1": "value1",
+			"key1":  "value1",
 			"key 2": "value2",
 		}}))
 		assert.Require(t, assert.Len(t, errs, 12))
-    fmt.Println(errs)
+		fmt.Println(errs)
 		assert.ElementsMatch(t, []*govy.PropertyError{
 			{
 				PropertyName:  "test.path",

--- a/pkg/govy/rules_for_map_test.go
+++ b/pkg/govy/rules_for_map_test.go
@@ -2,7 +2,6 @@ package govy_test
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/nobl9/govy/internal/assert"
@@ -133,7 +132,6 @@ func TestPropertyRulesForMap(t *testing.T) {
 			"key 2": "value2",
 		}}))
 		assert.Require(t, assert.Len(t, errs, 12))
-		fmt.Println(errs)
 		assert.ElementsMatch(t, []*govy.PropertyError{
 			{
 				PropertyName:  "test.path",

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -1,7 +1,7 @@
 package govy
 
 import (
-	"fmt"
+	"github.com/nobl9/govy/internal/jsonpath"
 )
 
 // ForSlice creates a new [PropertyRulesForSlice] instance for a slice property
@@ -56,7 +56,8 @@ func (r PropertyRulesForSlice[T, S]) Validate(st S) error {
 		}
 		for _, e := range forEachErrors {
 			e.IsSliceElementError = true
-			propErrs = append(propErrs, e.PrependParentPropertyName(SliceElementName(r.sliceRules.name, i)))
+			path := r.getJSONPathForIndex(i)
+			propErrs = append(propErrs, e.prependParentPropertyName(path))
 		}
 	}
 	if len(propErrs) > 0 {
@@ -131,10 +132,7 @@ func (r PropertyRulesForSlice[T, S]) plan(builder planBuilder) {
 	}
 }
 
-// SliceElementName generates a name for a slice element.
-func SliceElementName(sliceName string, index int) string {
-	if sliceName == "" {
-		return fmt.Sprintf("[%d]", index)
-	}
-	return fmt.Sprintf("%s[%d]", sliceName, index)
+// getJSONPathForIndex returns a JSONPath for the given index.
+func (r PropertyRulesForSlice[T, S]) getJSONPathForIndex(index int) string {
+	return jsonpath.JoinArray(r.sliceRules.name, jsonpath.NewArrayIndex(index))
 }


### PR DESCRIPTION
## Summary

The changes are currently scoped only to map keys.
In the future methods like `WithName` and name inferrence should be also addressed.

## Release Notes

When creating property paths for maps, govy will now use JSONPath escaping rules (best effort) to add map keys to the property path. For instance, if the key is `b az` and the current path is `foo.bar`, the resulting path will be `foo.bar.['b az']`.

## Breaking Changes

`govy.PropertyError.PrependParentPropertyName()` method has been hidden and is no longer part of the public API.
`govy.MapElementName` and `govy.SliceElementName` has been removed.