### PR TITLE
feat: Only print "for the following properties" in ValidatorError.Error() when there is at least one property name

### DIFF
--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -51,9 +51,22 @@ func (e *ValidatorError) Error() string {
 		b.WriteString(" at index ")
 		b.WriteString(strconv.Itoa(*e.SliceIndex))
 	}
-	b.WriteString(" has failed for the following properties:\n")
+	b.WriteString(" has failed")
+	if e.hasAtLeastOnePropertyName() {
+		b.WriteString(" for the following properties")
+	}
+	b.WriteString(":\n")
 	internal.JoinErrors(&b, e.Errors, strings.Repeat(" ", 2))
 	return b.String()
+}
+
+func (e *ValidatorError) hasAtLeastOnePropertyName() bool {
+	for _, e := range e.Errors {
+		if e.PropertyName != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidatorErrors is a slice of [ValidatorError].

--- a/pkg/govy/errors_test.go
+++ b/pkg/govy/errors_test.go
@@ -57,6 +57,16 @@ func TestValidatorError(t *testing.T) {
 				},
 			},
 		},
+		"no_prop_names": {
+			Errors: govy.PropertyErrors{
+				{
+					Errors: []*govy.RuleError{{Message: "no name"}},
+				},
+				{
+					Errors: []*govy.RuleError{{Message: "that is an error"}},
+				},
+			},
+		},
 	}
 
 	for name, err := range tests {

--- a/pkg/govy/errors_test.go
+++ b/pkg/govy/errors_test.go
@@ -67,6 +67,29 @@ func TestValidatorError(t *testing.T) {
 				},
 			},
 		},
+		"no_prop_names_and_validator_name": {
+			Name: "Teacher",
+			Errors: govy.PropertyErrors{
+				{
+					Errors: []*govy.RuleError{{Message: "no name"}},
+				},
+				{
+					Errors: []*govy.RuleError{{Message: "that is an error"}},
+				},
+			},
+		},
+		"no_prop_names_and_index": {
+			Name:       "Teacher",
+			SliceIndex: ptr(0),
+			Errors: govy.PropertyErrors{
+				{
+					Errors: []*govy.RuleError{{Message: "no name"}},
+				},
+				{
+					Errors: []*govy.RuleError{{Message: "that is an error"}},
+				},
+			},
+		},
 	}
 
 	for name, err := range tests {

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -52,7 +52,7 @@ func ExampleNew() {
 	}
 
 	// Output:
-	// Validation has failed for the following properties:
+	// Validation has failed:
 	//   - always fails
 }
 
@@ -70,7 +70,7 @@ func ExampleValidator_WithName() {
 	}
 
 	// Output:
-	// Validation for Teacher has failed for the following properties:
+	// Validation for Teacher has failed:
 	//   - always fails
 }
 
@@ -89,7 +89,7 @@ func ExampleValidator_WithNameFunc() {
 	}
 
 	// Output:
-	// Validation for Teacher John has failed for the following properties:
+	// Validation for Teacher John has failed:
 	//   - always fails
 }
 
@@ -118,7 +118,7 @@ func ExampleValidatorError_WithName() {
 	}
 
 	// Output:
-	// Validation for Jake has failed for the following properties:
+	// Validation for Jake has failed:
 	//   - always fails
 }
 
@@ -154,7 +154,7 @@ func ExampleValidator_When() {
 	}
 
 	// Output:
-	// Validation for Jerry has failed for the following properties:
+	// Validation for Jerry has failed:
 	//   - always fails
 }
 
@@ -506,7 +506,7 @@ func ExampleGetSelf() {
 	}
 
 	// Output:
-	// Validation for Teacher has failed for the following properties:
+	// Validation for Teacher has failed:
 	//   - now I have access to the whole teacher
 }
 

--- a/pkg/govy/test_data/validator_error_no_prop_names.txt
+++ b/pkg/govy/test_data/validator_error_no_prop_names.txt
@@ -1,0 +1,3 @@
+Validation has failed:
+  - no name
+  - that is an error

--- a/pkg/govy/test_data/validator_error_no_prop_names_and_index.txt
+++ b/pkg/govy/test_data/validator_error_no_prop_names_and_index.txt
@@ -1,0 +1,3 @@
+Validation for Teacher at index 0 has failed:
+  - no name
+  - that is an error

--- a/pkg/govy/test_data/validator_error_no_prop_names_and_validator_name.txt
+++ b/pkg/govy/test_data/validator_error_no_prop_names_and_validator_name.txt
@@ -1,0 +1,3 @@
+Validation for Teacher has failed:
+  - no name
+  - that is an error

--- a/pkg/govyconfig/example_test.go
+++ b/pkg/govyconfig/example_test.go
@@ -106,7 +106,7 @@ func ExampleNameInferModeGenerate() {
 	}
 
 	// Output:
-	// Validation for Teacher has failed for the following properties:
+	// Validation for Teacher has failed:
 	//   - should be equal to 'Jerry'
 	// Validation for NotTeacher has failed for the following properties:
 	//   - 'name' with value 'Tom':
@@ -135,7 +135,7 @@ func ExampleSetNameInferMode_invalidUsage() {
 	}
 
 	// Output:
-	// Validation for Teacher has failed for the following properties:
+	// Validation for Teacher has failed:
 	//   - should be equal to 'Jerry'
 }
 

--- a/pkg/govytest/assert_test.go
+++ b/pkg/govytest/assert_test.go
@@ -50,14 +50,14 @@ func TestAssertError(t *testing.T) {
 			ok:             false,
 			inputError:     &govy.ValidatorError{},
 			expectedErrors: []govytest.ExpectedRuleError{{}},
-			out: `Validation for ExpectedRuleError at index 0 has failed for the following properties:
+			out: `Validation for ExpectedRuleError at index 0 has failed:
   - one of [code, containsMessage, message] properties must be set, none was provided`,
 		},
 		"invalid input - second error": {
 			ok:             false,
 			inputError:     &govy.ValidatorError{},
 			expectedErrors: []govytest.ExpectedRuleError{{Message: "foo"}, {}},
-			out: `Validation for ExpectedRuleError at index 1 has failed for the following properties:
+			out: `Validation for ExpectedRuleError at index 1 has failed:
   - one of [code, containsMessage, message] properties must be set, none was provided`,
 		},
 		"no expected errors": {
@@ -374,7 +374,7 @@ func TestAssertError_ValidatorErrors(t *testing.T) {
 			ok:             false,
 			inputError:     govy.ValidatorErrors{{}},
 			expectedErrors: []govytest.ExpectedRuleError{{Message: "foo"}},
-			out: `Validation for ExpectedRuleError has failed for the following properties:
+			out: `Validation for ExpectedRuleError has failed:
   - one of [validatorIndex, validatorName] properties must be set, none was provided; The actual error was of type govy.ValidatorErrors.
     In order to match expected error with an actual error produced by a specific govy.Validator instance,
     either the name of the validator, its index (when using ValidateSlice method) or both must be provided.
@@ -575,7 +575,7 @@ func TestAssertErrorContains(t *testing.T) {
 			ok:            false,
 			inputError:    &govy.ValidatorError{},
 			expectedError: govytest.ExpectedRuleError{},
-			out: `Validation for ExpectedRuleError has failed for the following properties:
+			out: `Validation for ExpectedRuleError has failed:
   - one of [code, containsMessage, message] properties must be set, none was provided`,
 		},
 		"wrong type of error": {


### PR DESCRIPTION
## Release Notes

`govy.ValidatorError.Error()` now only prints _"for the following properties"_ when there is at least one property name.
If all the property errors have no name, it will simply print _"Validation has failed"_.
