### PR TITLE
fix: Correct govy.Plan rules aggregation and predicates handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,15 +649,7 @@ func Example_validationPlan() {
 	//       "typeInfo": {
 	//         "name": "string",
 	//         "kind": "string"
-	//       },
-	//       "rules": [
-	//         {
-	//           "description": "",
-	//           "conditions": [
-	//             "Teacher name is John"
-	//           ]
-	//         }
-	//       ]
+	//       }
 	//     }
 	//   ]
 	// }

--- a/go.work.sum
+++ b/go.work.sum
@@ -20,6 +20,7 @@ golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFK
 golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
 golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
 golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=

--- a/internal/examples/readme_validation_plan_example_test.go
+++ b/internal/examples/readme_validation_plan_example_test.go
@@ -171,15 +171,7 @@ func Example_validationPlan() {
 	//       "typeInfo": {
 	//         "name": "string",
 	//         "kind": "string"
-	//       },
-	//       "rules": [
-	//         {
-	//           "description": "",
-	//           "conditions": [
-	//             "Teacher name is John"
-	//           ]
-	//         }
-	//       ]
+	//       }
 	//     }
 	//   ]
 	// }

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -229,9 +229,7 @@ func (r PropertyRules[T, S]) cascadeInternal(mode CascadeMode) propertyRulesInte
 func (r PropertyRules[T, S]) plan(builder planBuilder) {
 	builder.propertyPlan.IsOptional = (r.omitEmpty || r.isPointer) && !r.required
 	builder.propertyPlan.IsHidden = r.hideValue
-	for _, predicate := range r.predicates {
-		builder.rulePlan.Conditions = append(builder.rulePlan.Conditions, predicate.description)
-	}
+	builder = appendPredicatesToPlanBuilder(builder, r.predicates)
 	if r.originalType != nil {
 		builder.propertyPlan.TypeInfo = TypeInfo(*r.originalType)
 	} else {

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -190,9 +190,7 @@ func (r PropertyRulesForMap[M, K, V, S]) cascadeInternal(mode CascadeMode) prope
 
 // plan constructs a validation plan for the property rules.
 func (r PropertyRulesForMap[M, K, V, S]) plan(builder planBuilder) {
-	for _, predicate := range r.predicates {
-		builder.rulePlan.Conditions = append(builder.rulePlan.Conditions, predicate.description)
-	}
+	builder = appendPredicatesToPlanBuilder(builder, r.predicates)
 	r.mapRules.plan(builder.setExamples(r.mapRules.examples...))
 	builder = builder.appendPath(r.mapRules.name)
 	// JSON/YAML path for keys uses '~' to extract the keys.

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -122,9 +122,7 @@ func (r PropertyRulesForSlice[T, S]) cascadeInternal(mode CascadeMode) propertyR
 
 // plan generates a validation plan for the property rules.
 func (r PropertyRulesForSlice[T, S]) plan(builder planBuilder) {
-	for _, predicate := range r.predicates {
-		builder.rulePlan.Conditions = append(builder.rulePlan.Conditions, predicate.description)
-	}
+	builder = appendPredicatesToPlanBuilder(builder, r.predicates)
 	r.sliceRules.plan(builder.setExamples(r.sliceRules.examples...))
 	builder = builder.appendPath(r.sliceRules.name)
 	if len(r.forEachRules.rules) > 0 {

--- a/pkg/govy/test_data/expected_conditions_without_rules_plan.json
+++ b/pkg/govy/test_data/expected_conditions_without_rules_plan.json
@@ -1,0 +1,25 @@
+{
+  "properties": [
+    {
+      "path": "$.Slice",
+      "typeInfo": {
+        "name": "Slice",
+        "kind": "[]string",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      },
+      "rules": [
+        {
+          "description": "length must be greater than or equal to 2",
+          "errorCode": "slice_min_length",
+          "conditions": [
+            "when true"
+          ]
+        },
+        {
+          "description": "length must be less than or equal to 1",
+          "errorCode": "slice_max_length"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -148,9 +148,7 @@ func (v Validator[S]) ValidateSlice(s []S) error {
 
 // plan constructs a validation plan for all the properties of the [Validator].
 func (v Validator[S]) plan(builder planBuilder) {
-	for _, predicate := range v.predicates {
-		builder.rulePlan.Conditions = append(builder.rulePlan.Conditions, predicate.description)
-	}
+	builder = appendPredicatesToPlanBuilder(builder, v.predicates)
 	for _, rules := range v.props {
 		if p, ok := rules.(planner); ok {
 			p.plan(builder)


### PR DESCRIPTION
## Motivation

Let's examine this example:

```go
type Slice []string
type Foo struct {
	Slice Slice
}
                                                                            
validator := govy.New(
	govy.For(func(f Foo) Slice { return f.Slice }).
		WithName("Slice").
		Include(govy.New(
			govy.For(govy.GetSelf[Slice]()).
				Rules(rules.SliceMaxLength[Slice](1)),
		)).
		When(func(f Foo) bool { return true }),
	govy.For(func(f Foo) Slice { return f.Slice }).
		WithName("Slice").
		When(func(f Foo) bool { return true }, govy.WhenDescription("when true")),
	govy.For(func(f Foo) Slice { return f.Slice }).
		WithName("Slice").
		When(func(f Foo) bool { return true }),
)
                                                                            
plan := govy.Plan(validator)
```

This will result in a Plan which looks like this:

```json
{
  "properties": [
    {
      "path": "$.Slice",
      "typeInfo": {
        "name": "Slice",
        "kind": "[]string",
        "package": "github.com/nobl9/govy/pkg/govy_test"
      },
      "rules": [
        {
          "description": "length must be less than or equal to 1",
          "errorCode": "slice_max_length",
          "conditions": [
            ""
          ]
        },
        {
          "description": "",
          "conditions": [
            "when true"
          ]
        },
        {
          "description": "",
          "conditions": [
            ""
          ]
        }
      ]
    }
  ]
}
```

Instead, what' we'd expect to see is:

```json
{
  "properties": [
    {
      "path": "$.Slice",
      "typeInfo": {
        "name": "Slice",
        "kind": "[]string",
        "package": "github.com/nobl9/govy/pkg/govy_test"
      },
      "rules": [
        {
          "description": "length must be less than or equal to 1",
          "errorCode": "slice_max_length"
        }
      ]
    }
  ]
}
```

## Testing

Added unit test to cover these scenarios.

## Release Notes

Fixed `govy.Plan` rules aggregation, it will no longer produce empty, fake rules. The predicates handling in the plan has been fix too, If a predicate has no description it will be omitted.