### PR TITLE
feat: Add required as a synthetic rule in govy.Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,6 @@ func Example_validationPlan() {
 			Required(),
 		govy.For(func(u University) string { return u.Address }).
 			WithName("address").
-			Required().
 			Rules(rules.StringMatchRegexp(
 				regexp.MustCompile(`[\w\s.]+, [0-9]{2}-[0-9]{3} \w+`),
 			).
@@ -527,7 +526,6 @@ func Example_validationPlan() {
 	teacherValidator := govy.New(
 		govy.For(func(t Teacher) string { return t.Name }).
 			WithName("name").
-			Required().
 			Rules(
 				rules.StringNotEmpty(),
 				rules.OneOf("Jake", "George")),
@@ -649,7 +647,16 @@ func Example_validationPlan() {
 	//       "typeInfo": {
 	//         "name": "string",
 	//         "kind": "string"
-	//       }
+	//       },
+	//       "rules": [
+	//         {
+	//           "description": "property is required",
+	//           "errorCode": "required",
+	//           "conditions": [
+	//             "Teacher name is John"
+	//           ]
+	//         }
+	//       ]
 	//     }
 	//   ]
 	// }

--- a/internal/examples/readme_validation_plan_example_test.go
+++ b/internal/examples/readme_validation_plan_example_test.go
@@ -32,7 +32,6 @@ func Example_validationPlan() {
 			Required(),
 		govy.For(func(u University) string { return u.Address }).
 			WithName("address").
-			Required().
 			Rules(rules.StringMatchRegexp(
 				regexp.MustCompile(`[\w\s.]+, [0-9]{2}-[0-9]{3} \w+`),
 			).
@@ -49,7 +48,6 @@ func Example_validationPlan() {
 	teacherValidator := govy.New(
 		govy.For(func(t Teacher) string { return t.Name }).
 			WithName("name").
-			Required().
 			Rules(
 				rules.StringNotEmpty(),
 				rules.OneOf("Jake", "George")),
@@ -171,7 +169,16 @@ func Example_validationPlan() {
 	//       "typeInfo": {
 	//         "name": "string",
 	//         "kind": "string"
-	//       }
+	//       },
+	//       "rules": [
+	//         {
+	//           "description": "property is required",
+	//           "errorCode": "required",
+	//           "conditions": [
+	//             "Teacher name is John"
+	//           ]
+	//         }
+	//       ]
 	//     }
 	//   ]
 	// }

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -9,11 +9,13 @@ import (
 	"sync"
 )
 
-const RequiredErrorMessage = "property is required but was empty"
+const (
+	RequiredErrorMessage    = "property is required but was empty"
+	RequiredDescription     = "property is required"
+	RequiredErrorCodeString = "required"
+)
 
-const RequiredErrorCodeString = "required"
-
-// IsEmptyFunc verifies if the value is zero value of its type.
+// IsEmpty verifies if the value is zero value of its type.
 func IsEmpty(v interface{}) bool {
 	if v == nil {
 		return true

--- a/pkg/govy/plan_test.go
+++ b/pkg/govy/plan_test.go
@@ -65,8 +65,7 @@ func TestPlan(t *testing.T) {
 			Rules(rules.StringNotEmpty()),
 		govy.For(func(p PodMetadata) string { return p.Namespace }).
 			WithName("namespace").
-			Required().
-			Rules(rules.StringNotEmpty()),
+			Required(),
 		govy.ForMap(func(p PodMetadata) Labels { return p.Labels }).
 			WithName("labels").
 			Rules(rules.MapMaxLength[Labels](10)).

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -236,6 +236,13 @@ func (r PropertyRules[T, S]) plan(builder planBuilder) {
 		builder.propertyPlan.TypeInfo = TypeInfo(typeinfo.Get[T]())
 	}
 	builder = builder.appendPath(r.name).setExamples(r.examples...)
+	if r.required {
+		// Dummy rule to register the property as required.
+		NewRule(func(v T) error { return nil }).
+			WithErrorCode(internal.RequiredErrorCodeString).
+			WithDescription(internal.RequiredDescription).
+			plan(builder)
+	}
 	for _, rule := range r.rules {
 		if p, ok := rule.(planner); ok {
 			p.plan(builder)

--- a/pkg/govy/test_data/expected_pod_plan.json
+++ b/pkg/govy/test_data/expected_pod_plan.json
@@ -13,6 +13,10 @@
       ],
       "rules": [
         {
+          "description": "property is required",
+          "errorCode": "required"
+        },
+        {
           "description": "must be one of: v1, v2",
           "errorCode": "one_of"
         }
@@ -30,8 +34,26 @@
       ],
       "rules": [
         {
+          "description": "property is required",
+          "errorCode": "required"
+        },
+        {
           "description": "should be equal to 'Pod'",
           "errorCode": "equal_to"
+        }
+      ]
+    },
+    {
+      "path": "$.metadata",
+      "typeInfo": {
+        "name": "PodMetadata",
+        "kind": "struct",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      },
+      "rules": [
+        {
+          "description": "property is required",
+          "errorCode": "required"
         }
       ]
     },
@@ -119,6 +141,10 @@
       },
       "rules": [
         {
+          "description": "property is required",
+          "errorCode": "required"
+        },
+        {
           "description": "string cannot be empty",
           "errorCode": "string_not_empty"
         }
@@ -132,8 +158,22 @@
       },
       "rules": [
         {
-          "description": "string cannot be empty",
-          "errorCode": "string_not_empty"
+          "description": "property is required",
+          "errorCode": "required"
+        }
+      ]
+    },
+    {
+      "path": "$.spec",
+      "typeInfo": {
+        "name": "PodSpec",
+        "kind": "struct",
+        "package": "github.com/nobl9/govy/pkg/govy_test"
+      },
+      "rules": [
+        {
+          "description": "property is required",
+          "errorCode": "required"
         }
       ]
     },
@@ -184,6 +224,10 @@
       },
       "rules": [
         {
+          "description": "property is required",
+          "errorCode": "required"
+        },
+        {
           "description": "string cannot be empty",
           "errorCode": "string_not_empty"
         }
@@ -196,6 +240,10 @@
         "kind": "string"
       },
       "rules": [
+        {
+          "description": "property is required",
+          "errorCode": "required"
+        },
         {
           "description": "length must be between 1 and 63",
           "errorCode": "string_dns_label:string_length"
@@ -222,6 +270,10 @@
         "Default"
       ],
       "rules": [
+        {
+          "description": "property is required",
+          "errorCode": "required"
+        },
         {
           "description": "must be one of: ClusterFirst, Default",
           "errorCode": "one_of"

--- a/pkg/rules/required.go
+++ b/pkg/rules/required.go
@@ -20,5 +20,5 @@ func Required[T any]() govy.Rule[T] {
 	}).
 		WithErrorCode(ErrorCodeRequired).
 		WithMessageTemplate(tpl).
-		WithDescription(mustExecuteTemplate(tpl, govy.TemplateVars{}))
+		WithDescription(internal.RequiredDescription)
 }


### PR DESCRIPTION
## Motivation

Currently, If we mark a `govy.PropertyRules` as `Required()`, it won't be reflected in the `govy.Plan` in any significant way.
Moreover, what If the same property is marked as required on a certain predicate?

## Summary

In order to support the usage of predicates, the plan builder is adding a synthetic `govy.Rule` with description set to "property is required" and error code set to "required".

## Release Notes

Properties marked as `Required` will now be reported as having the following rule in `govy.Plan`: `{"description":"property is required","errorCode":"required"}`.
