### PR TITLE
fix: Harden validation interface

### DIFF
--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -217,3 +217,6 @@ func examplesToString(examples []string) string {
 	b.WriteString(")")
 	return b.String()
 }
+
+// isRules implements [rulesInterface].
+func (r Rule[T]) isRules() {}

--- a/pkg/govy/rule_set.go
+++ b/pkg/govy/rule_set.go
@@ -74,3 +74,6 @@ func (r RuleSet[T]) plan(builder planBuilder) {
 		rule.plan(builder)
 	}
 }
+
+// isRules implements [rulesInterface].
+func (r RuleSet[T]) isRules() {}

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -167,13 +167,15 @@ func (r PropertyRules[T, S]) WithExamples(examples ...string) PropertyRules[T, S
 }
 
 // Rules associates provided [Rule] with the property.
-func (r PropertyRules[T, S]) Rules(rules ...validationInterface[T]) PropertyRules[T, S] {
-	r.rules = append(r.rules, rules...)
+func (r PropertyRules[T, S]) Rules(rules ...rulesInterface[T]) PropertyRules[T, S] {
+	for _, rule := range rules {
+		r.rules = append(r.rules, rule)
+	}
 	return r
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
-func (r PropertyRules[T, S]) Include(rules ...Validator[T]) PropertyRules[T, S] {
+func (r PropertyRules[T, S]) Include(rules ...validatorInterface[T]) PropertyRules[T, S] {
 	for _, rule := range rules {
 		r.rules = append(r.rules, rule)
 	}
@@ -307,3 +309,6 @@ func newRequiredError() *RuleError {
 		internal.RequiredErrorCode,
 	)
 }
+
+// isPropertyRules implements [propertyRulesInterface].
+func (r PropertyRules[T, S]) isPropertyRules() {}

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -109,7 +109,7 @@ func (r PropertyRulesForMap[M, K, V, S]) WithExamples(examples ...string) Proper
 
 // RulesForKeys adds [Rule] for map's keys.
 func (r PropertyRulesForMap[M, K, V, S]) RulesForKeys(
-	rules ...validationInterface[K],
+	rules ...rulesInterface[K],
 ) PropertyRulesForMap[M, K, V, S] {
 	r.forKeyRules = r.forKeyRules.Rules(rules...)
 	return r
@@ -117,7 +117,7 @@ func (r PropertyRulesForMap[M, K, V, S]) RulesForKeys(
 
 // RulesForValues adds [Rule] for map's values.
 func (r PropertyRulesForMap[M, K, V, S]) RulesForValues(
-	rules ...validationInterface[V],
+	rules ...rulesInterface[V],
 ) PropertyRulesForMap[M, K, V, S] {
 	r.forValueRules = r.forValueRules.Rules(rules...)
 	return r
@@ -126,14 +126,14 @@ func (r PropertyRulesForMap[M, K, V, S]) RulesForValues(
 // RulesForItems adds [Rule] for [MapItem].
 // It allows validating both key and value in conjunction.
 func (r PropertyRulesForMap[M, K, V, S]) RulesForItems(
-	rules ...validationInterface[MapItem[K, V]],
+	rules ...rulesInterface[MapItem[K, V]],
 ) PropertyRulesForMap[M, K, V, S] {
 	r.forItemRules = r.forItemRules.Rules(rules...)
 	return r
 }
 
 // Rules adds [Rule] for the whole map.
-func (r PropertyRulesForMap[M, K, V, S]) Rules(rules ...validationInterface[M]) PropertyRulesForMap[M, K, V, S] {
+func (r PropertyRulesForMap[M, K, V, S]) Rules(rules ...rulesInterface[M]) PropertyRulesForMap[M, K, V, S] {
 	r.mapRules = r.mapRules.Rules(rules...)
 	return r
 }
@@ -148,13 +148,17 @@ func (r PropertyRulesForMap[M, K, V, S]) When(
 }
 
 // IncludeForKeys associates specified [Validator] and its [PropertyRules] with map's keys.
-func (r PropertyRulesForMap[M, K, V, S]) IncludeForKeys(validators ...Validator[K]) PropertyRulesForMap[M, K, V, S] {
+func (r PropertyRulesForMap[M, K, V, S]) IncludeForKeys(
+	validators ...validatorInterface[K],
+) PropertyRulesForMap[M, K, V, S] {
 	r.forKeyRules = r.forKeyRules.Include(validators...)
 	return r
 }
 
 // IncludeForValues associates specified [Validator] and its [PropertyRules] with map's values.
-func (r PropertyRulesForMap[M, K, V, S]) IncludeForValues(rules ...Validator[V]) PropertyRulesForMap[M, K, V, S] {
+func (r PropertyRulesForMap[M, K, V, S]) IncludeForValues(
+	rules ...validatorInterface[V],
+) PropertyRulesForMap[M, K, V, S] {
 	r.forValueRules = r.forValueRules.Include(rules...)
 	return r
 }
@@ -162,7 +166,7 @@ func (r PropertyRulesForMap[M, K, V, S]) IncludeForValues(rules ...Validator[V])
 // IncludeForItems associates specified [Validator] and its [PropertyRules] with [MapItem].
 // It allows validating both key and value in conjunction.
 func (r PropertyRulesForMap[M, K, V, S]) IncludeForItems(
-	rules ...Validator[MapItem[K, V]],
+	rules ...validatorInterface[MapItem[K, V]],
 ) PropertyRulesForMap[M, K, V, S] {
 	r.forItemRules = r.forItemRules.Include(rules...)
 	return r
@@ -209,3 +213,6 @@ func (r PropertyRulesForMap[M, K, V, S]) plan(builder planBuilder) {
 func (r PropertyRulesForMap[M, K, V, S]) getJSONPathForKey(key any) string {
 	return jsonpath.Join(r.mapRules.name, jsonpath.EscapeSegment(fmt.Sprint(key)))
 }
+
+// isPropertyRules implements [propertyRulesInterface].
+func (r PropertyRulesForMap[M, K, V, S]) isPropertyRules() {}

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -79,13 +79,13 @@ func (r PropertyRulesForSlice[T, S]) WithExamples(examples ...string) PropertyRu
 }
 
 // RulesForEach adds [Rule] for each element of the slice.
-func (r PropertyRulesForSlice[T, S]) RulesForEach(rules ...validationInterface[T]) PropertyRulesForSlice[T, S] {
+func (r PropertyRulesForSlice[T, S]) RulesForEach(rules ...rulesInterface[T]) PropertyRulesForSlice[T, S] {
 	r.forEachRules = r.forEachRules.Rules(rules...)
 	return r
 }
 
 // Rules adds [Rule] for the whole slice.
-func (r PropertyRulesForSlice[T, S]) Rules(rules ...validationInterface[[]T]) PropertyRulesForSlice[T, S] {
+func (r PropertyRulesForSlice[T, S]) Rules(rules ...rulesInterface[[]T]) PropertyRulesForSlice[T, S] {
 	r.sliceRules = r.sliceRules.Rules(rules...)
 	return r
 }
@@ -97,7 +97,7 @@ func (r PropertyRulesForSlice[T, S]) When(predicate Predicate[S], opts ...WhenOp
 }
 
 // IncludeForEach associates specified [Validator] and its [PropertyRules] with each element of the slice.
-func (r PropertyRulesForSlice[T, S]) IncludeForEach(rules ...Validator[T]) PropertyRulesForSlice[T, S] {
+func (r PropertyRulesForSlice[T, S]) IncludeForEach(rules ...validatorInterface[T]) PropertyRulesForSlice[T, S] {
 	r.forEachRules = r.forEachRules.Include(rules...)
 	return r
 }
@@ -134,3 +134,6 @@ func (r PropertyRulesForSlice[T, S]) plan(builder planBuilder) {
 func (r PropertyRulesForSlice[T, S]) getJSONPathForIndex(index int) string {
 	return jsonpath.JoinArray(r.sliceRules.name, jsonpath.NewArrayIndex(index))
 }
+
+// isPropertyRules implements [propertyRulesInterface].
+func (r PropertyRulesForSlice[T, S]) isPropertyRules() {}

--- a/pkg/govy/validation.go
+++ b/pkg/govy/validation.go
@@ -1,0 +1,33 @@
+package govy
+
+// validationInterface is a common interface implemented by all validation entities.
+// These include [Validator], [PropertyRules] and [Rule].
+type validationInterface[T any] interface {
+	Validate(v T) error
+}
+
+// validatorInterface defines validation entities which group properties,
+// such as [Validator].
+type validatorInterface[S any] interface {
+	validationInterface[S]
+	isValidator()
+}
+
+// propertyRulesInterface defines validation entities which describe properties,
+// such as [PropertyRules], [PropertyRulesForSlice] and [PropertyRulesForMap].
+//
+// On top of [validationInterface] requirements it specifies internal functions
+// which allow interacting with [propertyRulesInterface] instances like [PropertyRules]
+// in an immutable fashion (no pointer receivers).
+type propertyRulesInterface[T any] interface {
+	validationInterface[T]
+	cascadeInternal(mode CascadeMode) propertyRulesInterface[T]
+	isPropertyRules()
+}
+
+// rulesInterface defines validation entities on the validation rule level,
+// such as [Rule] or [RuleSet].
+type rulesInterface[T any] interface {
+	validationInterface[T]
+	isRules()
+}

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -5,23 +5,6 @@ import (
 	"strings"
 )
 
-// validationInterface is a common interface implemented by all validation entities.
-// These include [Validator], [PropertyRules] and [Rule].
-type validationInterface[T any] interface {
-	Validate(s T) error
-}
-
-// propertyRulesInterface is an internal interface which further limits
-// what [New] constructor and [Validator] can accept as property rules.
-//
-// On top of [validationInterface] requirements it specifies internal functions
-// which allow interacting with [propertyRulesInterface] instances like [PropertyRules]
-// in an immutable fashion (no pointer receivers).
-type propertyRulesInterface[T any] interface {
-	validationInterface[T]
-	cascadeInternal(mode CascadeMode) propertyRulesInterface[T]
-}
-
 // New creates a new [Validator] aggregating the provided property rules.
 func New[S any](props ...propertyRulesInterface[S]) Validator[S] {
 	return Validator[S]{props: props}
@@ -155,3 +138,6 @@ func (v Validator[S]) plan(builder planBuilder) {
 		}
 	}
 }
+
+// isValidator implements [validatorInterface].
+func (v Validator[S]) isValidator() {}


### PR DESCRIPTION
## Motivation

Currently, due to how the `validationInterface` is used and defined, we can potentially write this code:

```go
	v3 := govy.New(
		govy.For(func(f Foo) Foo { return f }).
			Rules(
				govy.For(func(f Foo) Foo { return f }),
			),
	)
```

This is obviously a wrong usage of the `govy.PropertyRules` ad the `Rules()` method should only accept either `Rule` or `RuleSet`.

In order to fix this, we should define a dedicated interface for all 3 types of govy entities --> validator, properties and rules.

## Release Notes

`govy.PropertyRules.Rules()` and related functions will no longer accept a `govy.Validator` instance.