### PR TITLE
feat: Mature name inference mechanism

### DIFF
--- a/pkg/govy/infer_name.go
+++ b/pkg/govy/infer_name.go
@@ -8,19 +8,19 @@ import (
 	"github.com/nobl9/govy/pkg/govyconfig"
 )
 
-func inferName() string {
-	return inferNameWithMode(govyconfig.GetNameInferMode())
+func inferName(skipFrames int) string {
+	return inferNameWithMode(govyconfig.GetNameInferMode(), skipFrames)
 }
 
-func inferNameWithMode(mode govyconfig.NameInferMode) string {
+func inferNameWithMode(mode govyconfig.NameInferMode, skipFrames int) string {
 	switch mode {
 	case govyconfig.NameInferModeDisable:
 		return ""
 	case govyconfig.NameInferModeGenerate:
-		file, line := nameinfer.Frame(5)
+		file, line := nameinfer.Frame(skipFrames)
 		return govyconfig.GetInferredName(file, line)
 	case govyconfig.NameInferModeRuntime:
-		file, line := nameinfer.Frame(5)
+		file, line := nameinfer.Frame(skipFrames)
 		return nameinfer.InferName(file, line)
 	default:
 		logging.Logger().Error(fmt.Sprintf("unknown %T", mode))

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -10,7 +10,7 @@ import (
 // ForMap creates a new [PropertyRulesForMap] instance for a map property
 // which value is extracted through [PropertyGetter] function.
 func ForMap[M ~map[K]V, K comparable, V, S any](getter PropertyGetter[M, S]) PropertyRulesForMap[M, K, V, S] {
-	name := inferName()
+	name := inferName(5)
 	return PropertyRulesForMap[M, K, V, S]{
 		mapRules:      forConstructor(getter, name),
 		forKeyRules:   forConstructor(GetSelf[K](), ""),

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -7,7 +7,7 @@ import (
 // ForSlice creates a new [PropertyRulesForSlice] instance for a slice property
 // which value is extracted through [PropertyGetter] function.
 func ForSlice[T, S any](getter PropertyGetter[[]T, S]) PropertyRulesForSlice[T, S] {
-	name := inferName()
+	name := inferName(5)
 	return PropertyRulesForSlice[T, S]{
 		sliceRules:   forConstructor(GetSelf[[]T](), name),
 		forEachRules: forConstructor(GetSelf[T](), ""),

--- a/pkg/govy/rules_test.go
+++ b/pkg/govy/rules_test.go
@@ -422,6 +422,36 @@ func TestPropertyRules_InferName(t *testing.T) {
 	})
 }
 
+func BenchmarkFor(b *testing.B) {
+	for b.Loop() {
+		type mockStruct struct {
+			Field string `json:"field"`
+		}
+
+		_ = govy.For(func(m mockStruct) string { return m.Field })
+	}
+}
+
+func BenchmarkFor2_withCallers(b *testing.B) {
+	for b.Loop() {
+		type mockStruct struct {
+			Field string `json:"field"`
+		}
+
+		_ = govy.For2(func(m mockStruct) string { return m.Field })
+	}
+}
+
+func BenchmarkFor3_withCaller(b *testing.B) {
+	for b.Loop() {
+		type mockStruct struct {
+			Field string `json:"field"`
+		}
+
+		_ = govy.For3(func(m mockStruct) string { return m.Field })
+	}
+}
+
 func mustPropertyErrors(t *testing.T, err error) govy.PropertyErrors {
 	t.Helper()
 	return mustErrorType[govy.PropertyErrors](t, err)


### PR DESCRIPTION
## Motivation

Name inference has been an experimental feature for quiet a while.
I believe it has a lot of potential and it solves by far the greatest nuisance of `govy` and its main weakness compared to go-validator, which is the manual property name provisioning using `WithName()` method.

Aside from low test coverage of the package performing the inference, the only blocker to mark the feature as stable is the inference global config, which needs to be configured BEFORE any validator code is imported.
Since govy validators are often defined as global variables, they are initialized on import, which does not lend itself to a predictable and easy to understand evaluation of the name inference mechanism's mode.
The inference mechanism MUST be able to find the file and line which instantiates given `PropertyRules` and in order to do that, we need `runtime` package and its program counters.

So how do we solve that? I see two potential solutions:

1. Extend the constructors (e.g. `govy.For()`) with optional options (varargs) which would allow to set the inference per each property. This is by far the simplest option, although it will end up being VERY verbose If users want to use the mechanism across their whole codebase.
2. Lazy load property name. This was we're deferring the name evaluation once the `Validate()` method is called. This makes the first execution of the property validation slower, but it also makes the instantiation of the `PropertyRules` faster. On top of that, the ergonomics of the feature are vastly improved.

## Summary

Recap of changed code.

## Solutions and Performance

Compared solutions:

```go
func For[T, S any](getter PropertyGetter[T, S]) PropertyRules[T, S] {
	return forConstructor(getter, inferName(5))
}

func For2[T, S any](getter PropertyGetter[T, S]) PropertyRules[T, S] {
	rpc := make([]uintptr, 1)
	n := runtime.Callers(2, rpc)
	return forConstructor2(getter, func() string {
		var (
			once sync.Once
			name string
		)
		once.Do(func() {
			if n < 1 {
				return // No caller found, return empty name.
			}
			frame, _ := runtime.CallersFrames(rpc).Next()
			name = nameinfer.InferName(frame.File, frame.Line)
		})
		return name
	})
}

func For3[T, S any](getter PropertyGetter[T, S]) PropertyRules[T, S] {
	_, file, line, _ := runtime.Caller(2)
	return forConstructor2(getter, func() string {
		var (
			once sync.Once
			name string
		)
		once.Do(func() {
			name = nameinfer.InferName(file, line)
		})
		return name
	})
}
```

Benchmark code:

```go
type mockStruct struct {
	Field string `json:"field"`
}

func BenchmarkFor(b *testing.B) {
	for b.Loop() {
		_ = govy.For(func(m mockStruct) string { return m.Field })
	}
}

func BenchmarkFor2_withCallers(b *testing.B) {
	for b.Loop() {
		_ = govy.For2(func(m mockStruct) string { return m.Field })
	}
}

func BenchmarkFor3_withCaller(b *testing.B) {
	for b.Loop() {
		_ = govy.For3(func(m mockStruct) string { return m.Field })
	}
}
```

Benchmark results:

| Spec           | Value                                     |
|-----------------|-------------------------------------------|
| **goos**        | linux                                     |
| **goarch**      | amd64                                     |
| **pkg**         | github.com/nobl9/govy/pkg/govy            |
| **cpu**         | 13th Gen Intel(R) Core(TM) i7-13700H      |

| Benchmark Name                | N         | ns/op    | B/op | allocs/op |
|-------------------------------|-----------|----------|------|-----------|
| BenchmarkFor                  | 21968064  | 50.13    | 24   | 1         |
| BenchmarkFor2_withCallers     | 6722644   | 188.5    | 80   | 3         |
| BenchmarkFor3_withCaller      | 2079151   | 523.2    | 328  | 6         |


## Release Notes

If this change should be part of the Release Notes,
**replace this entire paragraph** with 1-3 sentences about the changes.
Otherwise, you **MUST** remove this section entirely.

Does this PR contain any breaking changes?
If so, add `## Breaking Changes` header and list the introduced changes there.
