### PR TITLE
fix: Correct govytest.Assert validator name matching

### DIFF
--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -106,7 +106,8 @@ func AssertNoError(t testingT, err error) bool {
 // If [ExpectedRuleError.IsKeyError] is provided it will be required to match
 // the actual [govy.PropertyError.IsKeyError].
 //
-// If the actual error is of type [govy.ValidatorErrors] the following two fields are also matched:
+// If the actual error is of type [govy.ValidatorErrors] either one of the following two fields must be provided.
+// Otherwise, there's no way to compare the expected and actual errors.
 //   - [ExpectedRuleError.ValidatorName] is equal to [govy.ValidatorError.Name]
 //   - [ExpectedRuleError.ValidatorIndex] is equal to [govy.ValidatorError.SliceIndex]
 //
@@ -356,6 +357,20 @@ func assertErrorMatches(
 	matched matchedErrors,
 ) bool {
 	t.Helper()
+
+	if expected.ValidatorName != "" && expected.ValidatorName != validatorErr.Name {
+		t.Errorf("Expected name '%s' of %T.Name but got '%s'", expected.ValidatorName, validatorErr, validatorErr.Name)
+		return false
+	}
+	if expected.ValidatorIndex != nil && *expected.ValidatorIndex != *validatorErr.SliceIndex {
+		t.Errorf(
+			"Expected index '%d' of %T.SliceIndex but got '%d'",
+			*expected.ValidatorIndex,
+			validatorErr,
+			*validatorErr.SliceIndex,
+		)
+		return false
+	}
 
 	multiMatch := false
 	for i, actual := range validatorErr.Errors {

--- a/pkg/govytest/assert.go
+++ b/pkg/govytest/assert.go
@@ -362,14 +362,24 @@ func assertErrorMatches(
 		t.Errorf("Expected name '%s' of %T.Name but got '%s'", expected.ValidatorName, validatorErr, validatorErr.Name)
 		return false
 	}
-	if expected.ValidatorIndex != nil && *expected.ValidatorIndex != *validatorErr.SliceIndex {
-		t.Errorf(
-			"Expected index '%d' of %T.SliceIndex but got '%d'",
-			*expected.ValidatorIndex,
-			validatorErr,
-			*validatorErr.SliceIndex,
-		)
-		return false
+	if expected.ValidatorIndex != nil {
+		switch {
+		case validatorErr.SliceIndex == nil:
+			t.Errorf(
+				"Expected index '%d' of %T.SliceIndex but got no index",
+				*expected.ValidatorIndex,
+				validatorErr,
+			)
+			return false
+		case *expected.ValidatorIndex != *validatorErr.SliceIndex:
+			t.Errorf(
+				"Expected index '%d' of %T.SliceIndex but got '%d'",
+				*expected.ValidatorIndex,
+				validatorErr,
+				*validatorErr.SliceIndex,
+			)
+			return false
+		}
 	}
 
 	multiMatch := false

--- a/pkg/govytest/assert_test.go
+++ b/pkg/govytest/assert_test.go
@@ -545,6 +545,84 @@ ACTUAL:
 			},
 			out: `*govy.ValidatorError contains different number of errors than expected, expected: 1, actual: 0.`,
 		},
+		"match ValidatorError by name": {
+			ok: true,
+			inputError: &govy.ValidatorError{
+				Name: "bar",
+				Errors: []*govy.PropertyError{
+					{
+						PropertyName: "that",
+						Errors:       []*govy.RuleError{{Message: "test"}},
+					},
+				},
+			},
+			expectedErrors: []govytest.ExpectedRuleError{
+				{PropertyName: "that", Message: "test", ValidatorName: "bar"},
+			},
+		},
+		"does not match ValidatorError by name": {
+			ok: false,
+			inputError: &govy.ValidatorError{
+				Name: "bar",
+				Errors: []*govy.PropertyError{
+					{
+						PropertyName: "that",
+						Errors:       []*govy.RuleError{{Message: "test"}},
+					},
+				},
+			},
+			expectedErrors: []govytest.ExpectedRuleError{
+				{PropertyName: "that", Message: "test", ValidatorName: "baz"},
+			},
+			out: "Expected name 'baz' of *govy.ValidatorError.Name but got 'bar'",
+		},
+		"match ValidatorError by index": {
+			ok: true,
+			inputError: &govy.ValidatorError{
+				SliceIndex: ptr(1),
+				Errors: []*govy.PropertyError{
+					{
+						PropertyName: "that",
+						Errors:       []*govy.RuleError{{Message: "test"}},
+					},
+				},
+			},
+			expectedErrors: []govytest.ExpectedRuleError{
+				{PropertyName: "that", Message: "test", ValidatorIndex: ptr(1)},
+			},
+		},
+		"does not match ValidatorError by index": {
+			ok: false,
+			inputError: &govy.ValidatorError{
+				SliceIndex: ptr(1),
+				Errors: []*govy.PropertyError{
+					{
+						PropertyName: "that",
+						Errors:       []*govy.RuleError{{Message: "test"}},
+					},
+				},
+			},
+			expectedErrors: []govytest.ExpectedRuleError{
+				{PropertyName: "that", Message: "test", ValidatorIndex: ptr(2)},
+			},
+			out: "Expected index '2' of *govy.ValidatorError.SliceIndex but got '1'",
+		},
+		"match ValidatorError by name and index": {
+			ok: true,
+			inputError: &govy.ValidatorError{
+				Name:       "bar",
+				SliceIndex: ptr(1),
+				Errors: []*govy.PropertyError{
+					{
+						PropertyName: "that",
+						Errors:       []*govy.RuleError{{Message: "test"}},
+					},
+				},
+			},
+			expectedErrors: []govytest.ExpectedRuleError{
+				{PropertyName: "that", Message: "test", ValidatorName: "bar", ValidatorIndex: ptr(1)},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/govytest/assert_test.go
+++ b/pkg/govytest/assert_test.go
@@ -607,6 +607,21 @@ ACTUAL:
 			},
 			out: "Expected index '2' of *govy.ValidatorError.SliceIndex but got '1'",
 		},
+		"does not match ValidatorError by index (no actual index)": {
+			ok: false,
+			inputError: &govy.ValidatorError{
+				Errors: []*govy.PropertyError{
+					{
+						PropertyName: "that",
+						Errors:       []*govy.RuleError{{Message: "test"}},
+					},
+				},
+			},
+			expectedErrors: []govytest.ExpectedRuleError{
+				{PropertyName: "that", Message: "test", ValidatorIndex: ptr(2)},
+			},
+			out: "Expected index '2' of *govy.ValidatorError.SliceIndex but got no index",
+		},
 		"match ValidatorError by name and index": {
 			ok: true,
 			inputError: &govy.ValidatorError{


### PR DESCRIPTION
## Motivation

When the actual error checked by `govytest.AssertError` is of type `govy.ValidatorError`, both validator name and index are ignored If we set them in `govytest.ExpectedRuleError`.
This selective behavior is ambiguous and makes it harder check an expected validator name is set for a given `govy.ValidatorError`.

## Release Notes

`govytest.AssertError` will now verify both validator name and index If the actual error is of type `govy.ValidatorError` and if these values are provided through `govytest.ExpectedRuleError`.
