### PR TITLE
chore: update Renovate configuration to include allowed commands

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,12 +24,16 @@
   "postUpdateOptions": ["gomodTidy"],
   "postUpgradeTasks": {
     "commands": [
-      "go work sync",
-      "make generate",
-      "make format",
+      "^go .*",
+      "^make .*",
     ],
     "executionMode": "branch",
   },
+  "allowedCommands": [
+    "go work sync",
+    "make generate",
+    "make format",
+  ],
   // Groups:
   "packageRules": [
     {


### PR DESCRIPTION
## Motivation

Without `allowedCommands`, `postUpgradeTasks` won't be allowed to run any commands.

## Summary

The Renovate configuration has been updated to introduce an `allowedCommands` field. This field explicitly lists the commands that are permitted during post-upgrade tasks, ensuring better control and security. The commands include `go work sync`, `make generate`, and `make format`. Additionally, the `commands` field in `postUpgradeTasks` has been adjusted to use regular expressions for broader matching of `go` and `make` commands.