### PR TITLE
chore: Remove post upgrade tasks from Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,19 +22,6 @@
   "commitMessagePrefix": "chore:",
   // This will run go mod tidy after each go.mod update.
   "postUpdateOptions": ["gomodTidy"],
-  "postUpgradeTasks": {
-    "commands": [
-      "go work sync",
-      "make generate",
-      "make format",
-    ],
-    "executionMode": "branch",
-  },
-  "allowedCommands": [
-    "go work sync",
-    "make generate",
-    "make format",
-  ],
   // Groups:
   "packageRules": [
     {


### PR DESCRIPTION
Turns out this is a paid feature.
