### PR TITLE
chore: restore GITHUB_TOKEN env for release-drafter v7

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -30,6 +30,8 @@ jobs:
       # write permission is required to create a github release
       contents: write
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.RELEASE_LABELER_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -30,6 +30,21 @@ jobs:
       # write permission is required to create a github release
       contents: write
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.drafter.outputs.tag_name }}
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - id: drafter
+        uses: release-drafter/release-drafter@v7
+        with:
+          token: ${{ secrets.RELEASE_LABELER_TOKEN }}
+
+  update_release_notes:
+    needs: update_release_draft
+    permissions:
+      # write permission is required to edit the github release
+      contents: write
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.RELEASE_LABELER_TOKEN }}
     steps:
@@ -37,11 +52,5 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          fetch-depth: 0
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - id: drafter
-        uses: release-drafter/release-drafter@v7
-        with:
-          token: ${{ secrets.RELEASE_LABELER_TOKEN }}
       - name: Add release notes to the draft
-        run: .github/scripts/release-notes.bash ${{ steps.drafter.outputs.tag_name }}
+        run: .github/scripts/release-notes.bash ${{ needs.update_release_draft.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- The release-drafter v7 upgrade removed the `GITHUB_TOKEN` env var in favor of the `token` input
- However, the `release-notes.bash` script uses `gh` CLI which requires `GITHUB_TOKEN` env var for authentication
- This restores the env var on the `update_release_draft` job