### PR TITLE
chore: unify rule error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ func Example_messageTemplates() {
 		Name string `json:"name"`
 	}
 
-	templateString := "name length should be between {{ .MinLength }} and {{ .MaxLength }} {{ formatExamples .Examples }}"
+	templateString := "name length must be between {{ .MinLength }} and {{ .MaxLength }} {{ formatExamples .Examples }}"
 
 	v := govy.New(
 		govy.For(func(t Teacher) string { return t.Name }).
@@ -336,7 +336,7 @@ func Example_messageTemplates() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Tom':
-	//     - name length should be between 5 and 10 (e.g. 'Joanna', 'Jerry')
+	//     - name length must be between 5 and 10 (e.g. 'Joanna', 'Jerry')
 }
 ```
 
@@ -589,7 +589,7 @@ func Example_validationPlan() {
 	//       ],
 	//       "rules": [
 	//         {
-	//           "description": "string cannot be empty",
+	//           "description": "string must not be empty",
 	//           "errorCode": "string_not_empty"
 	//         },
 	//         {
@@ -721,7 +721,7 @@ func Example_pathInference() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Tom':
-	//     - should be equal to 'Jerry'
+	//     - must be equal to 'Jerry'
 }
 ```
 

--- a/docs/validator-comparison/example_test.go
+++ b/docs/validator-comparison/example_test.go
@@ -221,9 +221,9 @@ func Example_govy() {
 	// Output:
 	// Validation has failed for the following properties:
 	//   - 'apiVersion' with value 'n9/v2alpha':
-	//     - should be equal to 'n9/v1alpha'
+	//     - must be equal to 'n9/v1alpha'
 	//   - 'kind' with value 'Project':
-	//     - should be equal to 'Service'
+	//     - must be equal to 'Service'
 	//   - 'metadata.name' with value 'slo-status api':
 	//     - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 	//   - 'metadata.project' with value 'default project':

--- a/internal/examples/readme_message_templates_example_test.go
+++ b/internal/examples/readme_message_templates_example_test.go
@@ -12,7 +12,7 @@ func Example_messageTemplates() {
 		Name string `json:"name"`
 	}
 
-	templateString := "name length should be between {{ .MinLength }} and {{ .MaxLength }} {{ formatExamples .Examples }}"
+	templateString := "name length must be between {{ .MinLength }} and {{ .MaxLength }} {{ formatExamples .Examples }}"
 
 	v := govy.New(
 		govy.For(func(t Teacher) string { return t.Name }).
@@ -33,5 +33,5 @@ func Example_messageTemplates() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Tom':
-	//     - name length should be between 5 and 10 (e.g. 'Joanna', 'Jerry')
+	//     - name length must be between 5 and 10 (e.g. 'Joanna', 'Jerry')
 }

--- a/internal/examples/readme_path_inference_example_test.go
+++ b/internal/examples/readme_path_inference_example_test.go
@@ -32,5 +32,5 @@ func Example_pathInference() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Tom':
-	//     - should be equal to 'Jerry'
+	//     - must be equal to 'Jerry'
 }

--- a/internal/examples/readme_validation_plan_example_test.go
+++ b/internal/examples/readme_validation_plan_example_test.go
@@ -109,7 +109,7 @@ func Example_validationPlan() {
 	//       ],
 	//       "rules": [
 	//         {
-	//           "description": "string cannot be empty",
+	//           "description": "string must not be empty",
 	//           "errorCode": "string_not_empty"
 	//         },
 	//         {

--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -75,12 +75,12 @@ var rawMessageTemplates = map[templateKey]string{
 	LengthTemplate:                  "length must be between {{ .MinLength }} and {{ .MaxLength }}",
 	MinLengthTemplate:               "length must be greater than or equal to {{ .ComparisonValue }}",
 	MaxLengthTemplate:               "length must be less than or equal to {{ .ComparisonValue }}",
-	EQTemplate:                      "should be equal to '{{ .ComparisonValue }}'",
-	NEQTemplate:                     "should be not equal to '{{ .ComparisonValue }}'",
-	GTTemplate:                      "should be greater than '{{ .ComparisonValue }}'",
-	GTETemplate:                     "should be greater than or equal to '{{ .ComparisonValue }}'",
-	LTTemplate:                      "should be less than '{{ .ComparisonValue }}'",
-	LTETemplate:                     "should be less than or equal to '{{ .ComparisonValue }}'",
+	EQTemplate:                      "must be equal to '{{ .ComparisonValue }}'",
+	NEQTemplate:                     "must not be equal to '{{ .ComparisonValue }}'",
+	GTTemplate:                      "must be greater than '{{ .ComparisonValue }}'",
+	GTETemplate:                     "must be greater than or equal to '{{ .ComparisonValue }}'",
+	LTTemplate:                      "must be less than '{{ .ComparisonValue }}'",
+	LTETemplate:                     "must be less than or equal to '{{ .ComparisonValue }}'",
 	EqualPropertiesTemplate:         `all of [{{ joinSlice .ComparisonValue "" }}] properties must be equal, but '{{ .Custom.FirstNotEqual }}' is not equal to '{{ .Custom.SecondNotEqual }}'`,
 	GTPropertiesTemplate:            `'{{ .Custom.FirstProperty }}' must be greater than '{{ .Custom.SecondProperty }}'`,
 	GTEPropertiesTemplate:           `'{{ .Custom.FirstProperty }}' must be greater than or equal to '{{ .Custom.SecondProperty }}'`,
@@ -110,7 +110,7 @@ var rawMessageTemplates = map[templateKey]string{
 {{- end }}
 `,
 	RequiredTemplate:          internal.RequiredMessage,
-	StringNonEmptyTemplate:    "string cannot be empty",
+	StringNonEmptyTemplate:    "string must not be empty",
 	StringMatchRegexpTemplate: "string must match regular expression: '{{ .ComparisonValue }}'",
 	StringDenyRegexpTemplate:  "string must not match regular expression: '{{ .ComparisonValue }}'",
 	StringEmailTemplate:       "string must be a valid email address: {{ .Error }}",
@@ -141,7 +141,7 @@ var rawMessageTemplates = map[templateKey]string{
 	StringTitleTemplate: "each word in a string must start with a capital letter",
 	StringGitRefTemplate: `
 {{- if eq .Custom.GitRefEmpty true -}}
-	git reference cannot be empty
+	git reference must not be empty
 {{- else if eq .Custom.GitRefEndsWithDot true -}}
 	git reference must not end with a '.'
 {{- else if eq .Custom.GitRefAtLeastOneSlash true -}}

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -263,7 +263,7 @@ func ExamplePropertyRules_WithName() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Jake':
-	//     - should be equal to 'Tom'
+	//     - must be equal to 'Tom'
 }
 
 // Beware that anything passed into [govy.PropertyRules.WithName] is treated as a single path segment.
@@ -337,9 +337,9 @@ func ExamplePropertyRules_WithPath() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'university.name' with value 'Poznan University of Technology':
-	//     - should be equal to 'Tom'
+	//     - must be equal to 'Tom'
 	//   - 'students[0].index' with value '1':
-	//     - should be equal to '2'
+	//     - must be equal to '2'
 }
 
 // [govy.For] constructor creates new [govy.PropertyRules] instance.
@@ -1028,7 +1028,7 @@ func ExampleRuleToPointer() {
 	// Output:
 	// Validation has failed for the following properties:
 	//   - 'pointer' with value 'bar':
-	//     - should be equal to 'foo'
+	//     - must be equal to 'foo'
 }
 
 // Sometimes it's useful to aggregate multiple [govy.Rule] into a single, composite rule.
@@ -1269,7 +1269,7 @@ func ExamplePropertyRules_Include() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Jerry':
-	//     - should be equal to 'Tom'
+	//     - must be equal to 'Tom'
 	//   - 'university.address':
 	//     - property is required but was empty
 }
@@ -1472,7 +1472,7 @@ func ExampleForMap() {
 	//   - 'students['9182300123']' with key '9182300123':
 	//     - length must be between 9 and 9
 	//   - 'students['9182300123'].name' with value 'Eve':
-	//     - should be not equal to 'Eve'
+	//     - must not be equal to 'Eve'
 	//   - 'students['918230013']' with value '{"name":"Joan","age":0,"students":null,"university":{"name":"","address":""}}':
 	//     - Joan cannot be a teacher for student with index 918230013
 }
@@ -1501,7 +1501,7 @@ func ExamplePropertyRules_When() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Jerry':
-	//     - should be not equal to 'Jerry'
+	//     - must not be equal to 'Jerry'
 }
 
 // To customize how [govy.Rule] are evaluated use [govy.PropertyRules.Cascade].
@@ -1538,7 +1538,7 @@ func ExamplePropertyRules_Cascade() {
 	//     - always fails
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Jerry':
-	//     - should be not equal to 'Jerry'
+	//     - must not be equal to 'Jerry'
 }
 
 // If combining [govy.New] with [govy.ForSlice] is not verbose enough for you,
@@ -1617,11 +1617,11 @@ func ExampleValidator_Cascade() {
 	// Output:
 	// Validation for Tom has failed for the following properties:
 	//   - 'age' with value '148920h0m0s':
-	//     - should be greater than '157680h0m0s'
+	//     - must be greater than '157680h0m0s'
 	// Validation for Jerry has failed for the following properties:
 	//   - 'name' with value 'Jerry':
-	//     - should be not equal to 'Jerry'
-	//     - should be equal to 'Tom'
+	//     - must not be equal to 'Jerry'
+	//     - must be equal to 'Tom'
 }
 
 // [govy.Validator.ValidateSlice] outputs [govy.ValidatorErrors] which is a slice of [govy.ValidatorError].
@@ -1872,7 +1872,7 @@ func ExamplePlan() {
 	//       ],
 	//       "rules": [
 	//         {
-	//           "description": "should be not equal to 'Jerry'",
+	//           "description": "must not be equal to 'Jerry'",
 	//           "details": "Jerry is just a name!",
 	//           "errorCode": "not_equal_to",
 	//           "conditions": [
@@ -2008,7 +2008,7 @@ func ExampleInferPathMode() {
 	// Output:
 	// Validation for Teacher has failed for the following properties:
 	//   - 'name' with value 'Tom':
-	//     - should be equal to 'Jerry'
+	//     - must be equal to 'Jerry'
 }
 
 // In the previous example we've seen [govy.InferPathModeRuntime] in action.
@@ -2055,10 +2055,10 @@ func ExampleInferPathModeGenerate() {
 
 	// Output:
 	// Validation for Teacher has failed:
-	//   - should be equal to 'Jerry'
+	//   - must be equal to 'Jerry'
 	// Validation for NotTeacher has failed for the following properties:
 	//   - 'name' with value 'Tom':
-	//     - should be equal to 'Thomas'
+	//     - must be equal to 'Thomas'
 }
 
 // Knowing when to call [govy.Validator.InferPath] is important.
@@ -2094,10 +2094,10 @@ func ExampleValidator_InferPath_changeModeInRuntime() {
 
 	// Output:
 	// Validation for Teacher has failed:
-	//   - should be equal to 'Jerry'
+	//   - must be equal to 'Jerry'
 	// ---
 	// After setting Runtime infer mode.
 	// ---
 	// Validation for Teacher has failed:
-	//   - should be equal to 'Jerry'
+	//   - must be equal to 'Jerry'
 }

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -98,19 +98,20 @@ func (emptyErr) Error() string { return "" }
 // It is the middle-level building block of the validation process,
 // aggregated by [Validator] and aggregating [Rule].
 type PropertyRules[T, P any] struct {
-	path            jsonpath.Path
-	pathFunc        inferPathFunc
-	getter          internalPropertyGetter[T, P]
-	transformGetter internalTransformPropertyGetter[T, P]
-	rules           []validationInterface[T]
-	required        bool
-	omitEmpty       bool
-	hideValue       bool
-	isPointer       bool
-	cascadeMode     CascadeMode
-	inferPathMode   InferPathMode
-	examples        []string
-	originalType    *typeinfo.TypeInfo
+	path             jsonpath.Path
+	pathFunc         inferPathFunc
+	getter           internalPropertyGetter[T, P]
+	transformGetter  internalTransformPropertyGetter[T, P]
+	rules            []validationInterface[T]
+	required         bool
+	omitEmpty        bool
+	hideValue        bool
+	isPointer        bool
+	cascadeMode      CascadeMode
+	inferPathMode    InferPathMode
+	inferPathModeSet bool
+	examples         []string
+	originalType     *typeinfo.TypeInfo
 
 	predicateMatcher[P]
 }
@@ -248,6 +249,7 @@ func (r PropertyRules[T, P]) Cascade(mode CascadeMode) PropertyRules[T, P] {
 // this setting will have no effect, acting like [InferPathModeDisable].
 func (r PropertyRules[T, P]) InferPath(mode InferPathMode) PropertyRules[T, P] {
 	r.inferPathMode = mode
+	r.inferPathModeSet = true
 	return r
 }
 
@@ -264,7 +266,7 @@ func (r PropertyRules[T, P]) cascadeInternal(mode CascadeMode) PropertyRulesInte
 // inferPathModeInternal is an internal wrapper around [PropertyRules.InferPath] which
 // fulfills [PropertyRulesInterface] interface.
 func (r PropertyRules[T, P]) inferPathModeInternal(mode InferPathMode) PropertyRulesInterface[P] {
-	if r.inferPathMode != 0 {
+	if r.inferPathModeSet {
 		return r
 	}
 	return r.InferPath(mode)

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -19,13 +19,14 @@ func ForMap[M ~map[K]V, K comparable, V, P any](getter PropertyGetter[M, P]) Pro
 
 // PropertyRulesForMap is responsible for validating a single property.
 type PropertyRulesForMap[M ~map[K]V, K comparable, V, P any] struct {
-	mapRules      PropertyRules[M, P]
-	forKeyRules   PropertyRules[K, K]
-	forValueRules PropertyRules[V, V]
-	forItemRules  PropertyRules[MapItem[K, V], MapItem[K, V]]
-	getter        PropertyGetter[M, P]
-	cascadeMode   CascadeMode
-	inferPathMode InferPathMode
+	mapRules         PropertyRules[M, P]
+	forKeyRules      PropertyRules[K, K]
+	forValueRules    PropertyRules[V, V]
+	forItemRules     PropertyRules[MapItem[K, V], MapItem[K, V]]
+	getter           PropertyGetter[M, P]
+	cascadeMode      CascadeMode
+	inferPathMode    InferPathMode
+	inferPathModeSet bool
 
 	predicateMatcher[P]
 }
@@ -198,6 +199,7 @@ func (r PropertyRulesForMap[M, K, V, P]) Cascade(mode CascadeMode) PropertyRules
 // InferPath => refer to [PropertyRules.InferPath] documentation.
 func (r PropertyRulesForMap[M, K, V, P]) InferPath(mode InferPathMode) PropertyRulesForMap[M, K, V, P] {
 	r.inferPathMode = mode
+	r.inferPathModeSet = true
 	r.mapRules = r.mapRules.InferPath(mode)
 	return r
 }
@@ -216,7 +218,7 @@ func (r PropertyRulesForMap[M, K, V, P]) cascadeInternal(mode CascadeMode) Prope
 // fulfills [PropertyRulesInterface] interface.
 // If the [InferPathMode] is already set, it won't change it.
 func (r PropertyRulesForMap[M, K, V, P]) inferPathModeInternal(mode InferPathMode) PropertyRulesInterface[P] {
-	if r.inferPathMode != 0 {
+	if r.inferPathModeSet {
 		return r
 	}
 	return r.InferPath(mode)

--- a/pkg/govy/rules_for_map_test.go
+++ b/pkg/govy/rules_for_map_test.go
@@ -446,5 +446,5 @@ func TestPropertyRulesForMap_InferPath(t *testing.T) {
 		RulesForKeys(rules.EQ("John"))
 	errs := mustPropertyErrors(t, r.Validate(Teacher{Students: map[string]int{"Luke": 35}}))
 	assert.Len(t, errs, 1)
-	assert.EqualError(t, errs, "- 'students.Luke' with key 'Luke':\n  - should be equal to 'John'")
+	assert.EqualError(t, errs, "- 'students.Luke' with key 'Luke':\n  - must be equal to 'John'")
 }

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -16,11 +16,12 @@ func ForSlice[S ~[]T, T, P any](getter PropertyGetter[S, P]) PropertyRulesForSli
 
 // PropertyRulesForSlice is responsible for validating a single property.
 type PropertyRulesForSlice[S ~[]T, T, P any] struct {
-	sliceRules    PropertyRules[S, S]
-	forEachRules  PropertyRules[T, T]
-	getter        PropertyGetter[S, P]
-	cascadeMode   CascadeMode
-	inferPathMode InferPathMode
+	sliceRules       PropertyRules[S, S]
+	forEachRules     PropertyRules[T, T]
+	getter           PropertyGetter[S, P]
+	cascadeMode      CascadeMode
+	inferPathMode    InferPathMode
+	inferPathModeSet bool
 
 	predicateMatcher[P]
 }
@@ -127,6 +128,7 @@ func (r PropertyRulesForSlice[S, T, P]) Cascade(mode CascadeMode) PropertyRulesF
 // InferPath => refer to [PropertyRules.InferPath] documentation.
 func (r PropertyRulesForSlice[S, T, P]) InferPath(mode InferPathMode) PropertyRulesForSlice[S, T, P] {
 	r.inferPathMode = mode
+	r.inferPathModeSet = true
 	r.sliceRules = r.sliceRules.InferPath(mode)
 	return r
 }
@@ -145,7 +147,7 @@ func (r PropertyRulesForSlice[S, T, P]) cascadeInternal(mode CascadeMode) Proper
 // fulfills [PropertyRulesInterface] interface.
 // If the [InferPathMode] is already set, it won't change it.
 func (r PropertyRulesForSlice[S, T, P]) inferPathModeInternal(mode InferPathMode) PropertyRulesInterface[P] {
-	if r.inferPathMode != 0 {
+	if r.inferPathModeSet {
 		return r
 	}
 	return r.InferPath(mode)

--- a/pkg/govy/rules_for_slice_test.go
+++ b/pkg/govy/rules_for_slice_test.go
@@ -239,5 +239,5 @@ func TestPropertyRulesForSlice_InferPath(t *testing.T) {
 		RulesForEach(rules.EQ("John"))
 	errs := mustPropertyErrors(t, r.Validate(Teacher{Students: []string{"Luke"}}))
 	assert.Len(t, errs, 1)
-	assert.EqualError(t, errs, "- 'students[0]' with value 'Luke':\n  - should be equal to 'John'")
+	assert.EqualError(t, errs, "- 'students[0]' with value 'Luke':\n  - must be equal to 'John'")
 }

--- a/pkg/govy/rules_test.go
+++ b/pkg/govy/rules_test.go
@@ -354,7 +354,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ("John"))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke"}))
 		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, "- 'name' with value 'Luke':\n  - should be equal to 'John'")
+		assert.EqualError(t, errs, "- 'name' with value 'Luke':\n  - must be equal to 'John'")
 	})
 	t.Run("selector expression getter", func(t *testing.T) {
 		r := govy.
@@ -363,7 +363,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ("John"))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke"}))
 		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, "- 'name' with value 'Luke':\n  - should be equal to 'John'")
+		assert.EqualError(t, errs, "- 'name' with value 'Luke':\n  - must be equal to 'John'")
 	})
 	t.Run("nested selector expression getter", func(t *testing.T) {
 		r := govy.
@@ -372,7 +372,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ(29))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke", Details: Details{Age: Age{Years: 30}}}))
 		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, "- 'details.age.years' with value '30':\n  - should be equal to '29'")
+		assert.EqualError(t, errs, "- 'details.age.years' with value '30':\n  - must be equal to '29'")
 	})
 	t.Run("variable assignment", func(t *testing.T) {
 		r := govy.
@@ -384,7 +384,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ("John"))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke"}))
 		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, "- 'name' with value 'Luke':\n  - should be equal to 'John'")
+		assert.EqualError(t, errs, "- 'name' with value 'Luke':\n  - must be equal to 'John'")
 	})
 	t.Run("nested selector variable assignment", func(t *testing.T) {
 		r := govy.
@@ -396,7 +396,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ(29))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke", Details: Details{Age: Age{Years: 30}}}))
 		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, "- 'details.age.years' with value '30':\n  - should be equal to '29'")
+		assert.EqualError(t, errs, "- 'details.age.years' with value '30':\n  - must be equal to '29'")
 	})
 	t.Run("external function", func(t *testing.T) {
 		getter := func(t Teacher) int {
@@ -409,7 +409,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ(29))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke", Details: Details{Age: Age{Years: 30}}}))
 		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, "- 'details.age.years' with value '30':\n  - should be equal to '29'")
+		assert.EqualError(t, errs, "- 'details.age.years' with value '30':\n  - must be equal to '29'")
 	})
 	t.Run("pointer", func(t *testing.T) {
 		r := govy.
@@ -418,7 +418,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ(ptr("No remarks")))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke", Remarks: ptr("Some remarks")}))
 		assert.Len(t, errs, 1)
-		assert.ErrorContains(t, errs, "- 'remarks' with value 'Some remarks':\n  - should be equal to '")
+		assert.ErrorContains(t, errs, "- 'remarks' with value 'Some remarks':\n  - must be equal to '")
 	})
 	t.Run("multiple return statements, infer from top level", func(t *testing.T) {
 		r := govy.
@@ -432,7 +432,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ(ptr("No remarks")))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke", Remarks: ptr("Some remarks")}))
 		assert.Len(t, errs, 1)
-		assert.ErrorContains(t, errs, "- 'remarks' with value 'Some remarks':\n  - should be equal to '")
+		assert.ErrorContains(t, errs, "- 'remarks' with value 'Some remarks':\n  - must be equal to '")
 	})
 	t.Run("multiple return statements, infer from nested if", func(t *testing.T) {
 		r := govy.
@@ -446,7 +446,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ(ptr("No remarks")))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Name: "Luke", Remarks: ptr("Some remarks")}))
 		assert.Len(t, errs, 1)
-		assert.ErrorContains(t, errs, "- 'remarks' with value 'Some remarks':\n  - should be equal to '")
+		assert.ErrorContains(t, errs, "- 'remarks' with value 'Some remarks':\n  - must be equal to '")
 	})
 	t.Run("no json tag", func(t *testing.T) {
 		r := govy.
@@ -455,7 +455,7 @@ func TestPropertyRules_InferPath(t *testing.T) {
 			Rules(rules.EQ("Cormack"))
 		errs := mustPropertyErrors(t, r.Validate(Teacher{Surname: "Ellis"}))
 		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, "- 'Surname' with value 'Ellis':\n  - should be equal to 'Cormack'")
+		assert.EqualError(t, errs, "- 'Surname' with value 'Ellis':\n  - must be equal to 'Cormack'")
 	})
 }
 

--- a/pkg/govy/test_data/expected_pod_plan.json
+++ b/pkg/govy/test_data/expected_pod_plan.json
@@ -38,7 +38,7 @@
           "errorCode": "required"
         },
         {
-          "description": "should be equal to 'Pod'",
+          "description": "must be equal to 'Pod'",
           "errorCode": "equal_to"
         }
       ]
@@ -145,7 +145,7 @@
           "errorCode": "required"
         },
         {
-          "description": "string cannot be empty",
+          "description": "string must not be empty",
           "errorCode": "string_not_empty"
         }
       ]
@@ -228,7 +228,7 @@
           "errorCode": "required"
         },
         {
-          "description": "string cannot be empty",
+          "description": "string must not be empty",
           "errorCode": "string_not_empty"
         }
       ]

--- a/pkg/govy/test_data/expected_values_intersection_plan.json
+++ b/pkg/govy/test_data/expected_values_intersection_plan.json
@@ -11,7 +11,7 @@
       ],
       "rules": [
         {
-          "description": "should be not equal to 'baz'",
+          "description": "must not be equal to 'baz'",
           "errorCode": "not_equal_to"
         },
         {
@@ -19,7 +19,7 @@
           "errorCode": "one_of"
         },
         {
-          "description": "should be equal to 'foo'",
+          "description": "must be equal to 'foo'",
           "errorCode": "equal_to"
         },
         {

--- a/pkg/govy/validator_test.go
+++ b/pkg/govy/validator_test.go
@@ -519,16 +519,16 @@ func TestValidatorInferPath(t *testing.T) {
 			errs,
 			govytest.ExpectedRuleError{
 				PropertyPath: "name",
-				Message:      "should be equal to 'expected'",
+				Message:      "must be equal to 'expected'",
 			},
 			govytest.ExpectedRuleError{
 				PropertyPath: "students[0]",
-				Message:      "should be equal to 'expected'",
+				Message:      "must be equal to 'expected'",
 			},
 			govytest.ExpectedRuleError{
 				PropertyPath: "grades.actual",
 				IsKeyError:   true,
-				Message:      "should be equal to 'expected'",
+				Message:      "must be equal to 'expected'",
 			},
 		)
 	})
@@ -565,16 +565,16 @@ func TestValidatorInferPath(t *testing.T) {
 			errs,
 			govytest.ExpectedRuleError{
 				PropertyPath: "", // Path inference is disabled.
-				Message:      "should be equal to 'expected'",
+				Message:      "must be equal to 'expected'",
 			},
 			govytest.ExpectedRuleError{
 				PropertyPath: "students[0]", // Runtime mode.
-				Message:      "should be equal to 'expected'",
+				Message:      "must be equal to 'expected'",
 			},
 			govytest.ExpectedRuleError{
 				PropertyPath: "['generated-students'].actual", // Generate mode.
 				IsKeyError:   true,
-				Message:      "should be equal to 'expected'",
+				Message:      "must be equal to 'expected'",
 			},
 		)
 	})
@@ -601,12 +601,12 @@ func TestValidatorInferPath(t *testing.T) {
 		govytest.AssertError(
 			t,
 			errs,
-			govytest.ExpectedRuleError{PropertyPath: "name", Message: "should be equal to 'expected'"},
-			govytest.ExpectedRuleError{PropertyPath: "students[0]", Message: "should be equal to 'expected'"},
+			govytest.ExpectedRuleError{PropertyPath: "name", Message: "must be equal to 'expected'"},
+			govytest.ExpectedRuleError{PropertyPath: "students[0]", Message: "must be equal to 'expected'"},
 			govytest.ExpectedRuleError{
 				PropertyPath: "grades.actual",
 				IsKeyError:   true,
-				Message:      "should be equal to 'expected'",
+				Message:      "must be equal to 'expected'",
 			},
 		)
 	})

--- a/pkg/rules/comparable_test.go
+++ b/pkg/rules/comparable_test.go
@@ -16,7 +16,7 @@ var eqTestCases = []*struct {
 	expectedError string
 }{
 	{value: 1, input: 1},
-	{value: 1.1, input: 1.3, expectedError: "should be equal to '1.1'"},
+	{value: 1.1, input: 1.3, expectedError: "must be equal to '1.1'"},
 }
 
 func TestEQ(t *testing.T) {
@@ -47,7 +47,7 @@ var neqTestCases = []*struct {
 	expectedError string
 }{
 	{value: 1.1, input: 1.3},
-	{value: 1.1, input: 1.1, expectedError: "should be not equal to '1.1'"},
+	{value: 1.1, input: 1.1, expectedError: "must not be equal to '1.1'"},
 }
 
 func TestNEQ(t *testing.T) {
@@ -78,8 +78,8 @@ var gtTestCases = []*struct {
 	expectedError string
 }{
 	{value: 1, input: 2},
-	{value: 1, input: 1, expectedError: "should be greater than '1'"},
-	{value: 4, input: 2, expectedError: "should be greater than '4'"},
+	{value: 1, input: 1, expectedError: "must be greater than '1'"},
+	{value: 4, input: 2, expectedError: "must be greater than '4'"},
 }
 
 func TestGT(t *testing.T) {
@@ -111,7 +111,7 @@ var gteTestCases = []*struct {
 }{
 	{value: 1, input: 1},
 	{value: 2, input: 4},
-	{value: 4, input: 2, expectedError: "should be greater than or equal to '4'"},
+	{value: 4, input: 2, expectedError: "must be greater than or equal to '4'"},
 }
 
 func TestGTE(t *testing.T) {
@@ -142,8 +142,8 @@ var ltTestCases = []*struct {
 	expectedError string
 }{
 	{value: 4, input: 2},
-	{value: 1, input: 1, expectedError: "should be less than '1'"},
-	{value: 2, input: 4, expectedError: "should be less than '2'"},
+	{value: 1, input: 1, expectedError: "must be less than '1'"},
+	{value: 2, input: 4, expectedError: "must be less than '2'"},
 }
 
 func TestLT(t *testing.T) {
@@ -175,7 +175,7 @@ var lteTestCases = []*struct {
 }{
 	{value: 1, input: 1},
 	{value: 4, input: 2},
-	{value: 2, input: 4, expectedError: "should be less than or equal to '2'"},
+	{value: 2, input: 4, expectedError: "must be less than or equal to '2'"},
 }
 
 func TestLTE(t *testing.T) {

--- a/pkg/rules/string_test.go
+++ b/pkg/rules/string_test.go
@@ -961,7 +961,7 @@ func BenchmarkStringTitle(b *testing.B) {
 }
 
 var (
-	errGitRefEmpty           = errors.New("git reference cannot be empty")
+	errGitRefEmpty           = errors.New("git reference must not be empty")
 	errGitRefEndsWithDot     = errors.New("git reference must not end with a '.'")
 	errGitRefAtLeastOneSlash = errors.New("git reference must contain at least one '/'")
 	errGitRefEmptyPart       = errors.New("git reference must not have empty parts")


### PR DESCRIPTION
## Motivation

Validation rule errors currently mix wording such as `should`, `must`, and `cannot`. This makes the public error output inconsistent and leaves message wording harder to reason about across rules.

Closes #211.

## Summary

- Standardizes comparison and non-empty rule messages on `must` wording.
- Updates README examples, tests, and generated validation plan fixtures for the new messages.
- Preserves explicit `InferPathModeDisable` when validator-level inference is configured, which removes the noisy generated-path lookup log exposed by the benchmark test run.

## Testing

Updated the existing unit and example expectations that cover the changed validation messages. Also reproduced the infer-path benchmark log noise and verified it no longer appears in the benchmark target output.

## Release Notes

Validation rule error messages now consistently use `must` wording across comparison and non-empty string/git reference rules.

## Breaking Changes

Validation error message text changed for comparison rules and non-empty string/git reference rules. Consumers that assert on exact message strings may need to update their expectations.
