### PR TITLE
chore: remove Key from jsonpath constructor

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -49,6 +49,7 @@ golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJ
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 h1:bTLqdHv7xrGlFbvf5/TXNxy/iUwwdkjhqQTJDjW7aj0=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
+golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
 golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
@@ -61,6 +62,7 @@ golang.org/x/term v0.36.0/go.mod h1:Qu394IJq6V6dCBRgwqshf3mPF85AqzYEzofzRdZkWss=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=

--- a/internal/inferpath/infer.go
+++ b/internal/inferpath/infer.go
@@ -361,7 +361,7 @@ func (n pathFinder) findPathInIndexExpr(
 }
 
 // appendIndexExpr appends an index expression to the path.
-// For integer literals it uses [Path.Index], for string literals [Path.Key],
+// For integer literals it uses [Path.Index], for string literals [Path.Name],
 // and for non-literal expressions it falls back to a raw "[]" segment.
 func (n pathFinder) appendIndexExpr(path jsonpath.Path, index ast.Expr) jsonpath.Path {
 	lit, ok := index.(*ast.BasicLit)
@@ -383,7 +383,7 @@ func (n pathFinder) appendIndexExpr(path jsonpath.Path, index ast.Expr) jsonpath
 			logging.Logger().Debug(fmt.Sprintf("failed to unquote string literal: %v", err))
 			return path.UnknownIndex()
 		}
-		return path.Key(key)
+		return path.Name(key)
 	default:
 		logging.Logger().Debug(fmt.Sprintf("unhandled BasicLit kind in index expression: %v", lit.Kind))
 	}

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -1,6 +1,8 @@
 package govy
 
 import (
+	"fmt"
+
 	"github.com/nobl9/govy/internal"
 	"github.com/nobl9/govy/pkg/jsonpath"
 )
@@ -241,7 +243,7 @@ func (r PropertyRulesForMap[M, K, V, P]) plan(builder planBuilder) {
 }
 
 func (r PropertyRulesForMap[M, K, V, P]) getPathForKey(key any) jsonpath.Path {
-	return r.mapRules.getPath().Key(key)
+	return r.mapRules.getPath().Name(fmt.Sprint(key))
 }
 
 func (r PropertyRulesForMap[M, K, V, P]) getPath() jsonpath.Path {

--- a/pkg/jsonpath/path.go
+++ b/pkg/jsonpath/path.go
@@ -2,7 +2,6 @@ package jsonpath
 
 import (
 	"cmp"
-	"fmt"
 	"slices"
 	"strconv"
 	"strings"
@@ -80,12 +79,6 @@ func (p Path) KeyWildcard() Path {
 // IndexWildcard appends an array wildcard segment to the path.
 func (p Path) IndexWildcard() Path {
 	return p.appendSegment(segment{kind: segmentValueWildcard, name: indexWildcard})
-}
-
-// Key appends a map key segment to the path, escaping special characters as needed.
-// Keys are stored as name segments since they render identically.
-func (p Path) Key(key any) Path {
-	return p.appendSegment(segment{kind: segmentName, name: fmt.Sprint(key)})
 }
 
 // Join appends another [Path] to this one.

--- a/pkg/jsonpath/path_test.go
+++ b/pkg/jsonpath/path_test.go
@@ -167,35 +167,6 @@ func TestParsePath(t *testing.T) {
 	}
 }
 
-func TestPath_Key(t *testing.T) {
-	tests := map[string]struct {
-		path     jsonpath.Path
-		expected string
-	}{
-		"simple key": {
-			path:     jsonpath.New().Name("map").Key("myKey"),
-			expected: "map.myKey",
-		},
-		"key with dot": {
-			path:     jsonpath.New().Name("map").Key("complex.key"),
-			expected: "map['complex.key']",
-		},
-		"integer key": {
-			path:     jsonpath.New().Name("map").Key(42),
-			expected: "map['42']",
-		},
-		"key only": {
-			path:     jsonpath.New().Key("solo"),
-			expected: "solo",
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.path.String())
-		})
-	}
-}
-
 func TestPath_JoinPath(t *testing.T) {
 	tests := map[string]struct {
 		base     jsonpath.Path


### PR DESCRIPTION
## Breaking Changes

`Key` method on `jsonpath.Path` introduced in prior version of `govy` has been removed as it is logically equal to `Name`.