### PR TITLE
feat: add configurable URL validation options

### DIFF
--- a/internal/messagetemplates/templates.go
+++ b/internal/messagetemplates/templates.go
@@ -187,7 +187,21 @@ var rawMessageTemplates = map[templateKey]string{
 {{- if gt (len .Custom.Constraints) 0 }} based on constraints: {{ joinSlice .Custom.Constraints "" }}{{- end }}`,
 	UniquePropertiesTemplate: `all of [{{ joinSlice .ComparisonValue "" }}] properties must be unique, but '{{ .Custom.FirstProperty }}' collides with '{{ .Custom.SecondProperty }}'
 {{- if gt (len .Custom.Constraints) 0 }}, based on constraints: {{ joinSlice .Custom.Constraints "" }}{{- end }}`,
-	URLTemplate: "{{ .Error }}",
+	URLTemplate: `
+{{- if .Error -}}
+	{{ .Error }}
+{{- else if .Custom.Scheme -}}
+	valid URL must use one of the following schemes: {{ joinSlice .ComparisonValue "'" }}
+{{- else if .Custom.HostRequired -}}
+	valid URL must have a host
+{{- else if .Custom.UserInfoForbidden -}}
+	valid URL must not contain user information
+{{- else if .Custom.HostDenyList -}}
+	valid URL must not use any of the following hostnames: {{ joinSlice .ComparisonValue "'" }}
+{{- else if .Custom.HostAllowList -}}
+	valid URL must use one of the following hostnames: {{ joinSlice .ComparisonValue "'" }}
+{{- end }}
+`,
 }
 
 // templateDependencies defines dependency templates for a given template.

--- a/pkg/rules/example_test.go
+++ b/pkg/rules/example_test.go
@@ -2,6 +2,7 @@ package rules_test
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/nobl9/govy/pkg/govy"
@@ -16,6 +17,35 @@ type Student struct {
 	Index     string `json:"index,omitempty"`
 	Name      string `json:"name,omitempty"`
 	IndexCopy string `json:"indexCopy,omitempty"`
+}
+
+func ExampleURL_withOptions() {
+	rule := rules.URL(
+		rules.URLHostRequired(),
+		rules.URLSchemes("https"),
+		rules.URLUserInfoForbidden(),
+		rules.URLHostAllowList("api.example.com"),
+	)
+	mustParseURL := func(rawURL string) *url.URL {
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			panic(err)
+		}
+		return parsedURL
+	}
+
+	fmt.Println(rule.Validate(mustParseURL("https://api.example.com/v1")) == nil)
+	fmt.Println(rule.Validate(mustParseURL("http://api.example.com/v1")))
+	fmt.Println(rule.Validate(mustParseURL("mailto:alerts@example.com")))
+	fmt.Println(rule.Validate(mustParseURL("https://user@api.example.com/v1")))
+	fmt.Println(rule.Validate(mustParseURL("https://billing.example.com/v1")))
+
+	// Output:
+	// true
+	// valid URL must use one of the following schemes: 'https'
+	// valid URL must have a host
+	// valid URL must not contain user information
+	// valid URL must use one of the following hostnames: 'api.example.com'
 }
 
 func ExampleSliceUnique() {

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -19,6 +19,11 @@ func TestRules_EnsureTestsAndBenchmarksAreWritten(t *testing.T) {
 		"HashFuncSelf":         true,
 		"CompareFunc":          true,
 		"CompareDeepEqualFunc": true,
+		"URLSchemes":           true,
+		"URLHostRequired":      true,
+		"URLUserInfoForbidden": true,
+		"URLHostAllowList":     true,
+		"URLHostDenyList":      true,
 	}
 	rulesDir := filepath.Join(internal.FindModuleRoot(), "pkg/rules")
 	fset := token.NewFileSet()

--- a/pkg/rules/url.go
+++ b/pkg/rules/url.go
@@ -39,7 +39,7 @@ type urlTemplateVars struct {
 // URLSchemes restricts [URL] to the provided schemes.
 func URLSchemes(schemes ...string) URLOption {
 	return urlOptionFunc(func(options *urlRuleOptions) {
-		options.schemes = slices.Clone(schemes)
+		options.schemes = schemes
 	})
 }
 

--- a/pkg/rules/url.go
+++ b/pkg/rules/url.go
@@ -3,7 +3,6 @@ package rules
 import (
 	"errors"
 	"net/url"
-	"slices"
 
 	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
@@ -11,21 +10,13 @@ import (
 
 // URLOption configures additional checks for [URL].
 type URLOption interface {
-	apply(*urlRuleOptions)
+	validate(*url.URL) (govy.TemplateVars, bool)
 }
 
-type urlOptionFunc func(*urlRuleOptions)
+type urlOptionFunc func(*url.URL) (govy.TemplateVars, bool)
 
-func (f urlOptionFunc) apply(options *urlRuleOptions) {
-	f(options)
-}
-
-type urlRuleOptions struct {
-	schemes       []string
-	hostRequired  bool
-	forbidUser    bool
-	hostAllowList []string
-	hostDenyList  []string
+func (f urlOptionFunc) validate(u *url.URL) (govy.TemplateVars, bool) {
+	return f(u)
 }
 
 type urlTemplateVars struct {
@@ -38,37 +29,71 @@ type urlTemplateVars struct {
 
 // URLSchemes restricts [URL] to the provided schemes.
 func URLSchemes(schemes ...string) URLOption {
-	return urlOptionFunc(func(options *urlRuleOptions) {
-		options.schemes = schemes
+	return urlOptionFunc(func(u *url.URL) (govy.TemplateVars, bool) {
+		if len(schemes) == 0 || containsString(schemes, u.Scheme) {
+			return govy.TemplateVars{}, true
+		}
+		return govy.TemplateVars{
+			PropertyValue:   u,
+			ComparisonValue: schemes,
+			Custom:          urlTemplateVars{Scheme: true},
+		}, false
 	})
 }
 
 // URLHostRequired requires [URL] values to have a host.
 func URLHostRequired() URLOption {
-	return urlOptionFunc(func(options *urlRuleOptions) {
-		options.hostRequired = true
+	return urlOptionFunc(func(u *url.URL) (govy.TemplateVars, bool) {
+		if u.Hostname() != "" {
+			return govy.TemplateVars{}, true
+		}
+		return govy.TemplateVars{
+			PropertyValue: u,
+			Custom:        urlTemplateVars{HostRequired: true},
+		}, false
 	})
 }
 
 // URLUserInfoForbidden rejects [URL] values with user information.
 func URLUserInfoForbidden() URLOption {
-	return urlOptionFunc(func(options *urlRuleOptions) {
-		options.forbidUser = true
+	return urlOptionFunc(func(u *url.URL) (govy.TemplateVars, bool) {
+		if u.User == nil {
+			return govy.TemplateVars{}, true
+		}
+		return govy.TemplateVars{
+			PropertyValue: u,
+			Custom:        urlTemplateVars{UserInfoForbidden: true},
+		}, false
 	})
 }
 
 // URLHostAllowList restricts [URL] values to the provided hostnames.
 func URLHostAllowList(hosts ...string) URLOption {
-	return urlOptionFunc(func(options *urlRuleOptions) {
-		options.hostAllowList = slices.Clone(hosts)
+	return urlOptionFunc(func(u *url.URL) (govy.TemplateVars, bool) {
+		hostname := u.Hostname()
+		if len(hosts) == 0 || containsString(hosts, hostname) {
+			return govy.TemplateVars{}, true
+		}
+		return govy.TemplateVars{
+			PropertyValue:   u,
+			ComparisonValue: hosts,
+			Custom:          urlTemplateVars{HostAllowList: true},
+		}, false
 	})
 }
 
 // URLHostDenyList rejects [URL] values with the provided hostnames.
-// Denied entries take precedence over entries defined with [URLHostAllowList].
 func URLHostDenyList(hosts ...string) URLOption {
-	return urlOptionFunc(func(options *urlRuleOptions) {
-		options.hostDenyList = slices.Clone(hosts)
+	return urlOptionFunc(func(u *url.URL) (govy.TemplateVars, bool) {
+		hostname := u.Hostname()
+		if len(hosts) == 0 || !containsString(hosts, hostname) {
+			return govy.TemplateVars{}, true
+		}
+		return govy.TemplateVars{
+			PropertyValue:   u,
+			ComparisonValue: hosts,
+			Custom:          urlTemplateVars{HostDenyList: true},
+		}, false
 	})
 }
 
@@ -76,7 +101,6 @@ func URLHostDenyList(hosts ...string) URLOption {
 // The URL must have a scheme (e.g. https://) and contain either host, fragment or opaque data.
 func URL(options ...URLOption) govy.Rule[*url.URL] {
 	tpl := messagetemplates.Get(messagetemplates.URLTemplate)
-	ruleOptions := newURLRuleOptions(options...)
 
 	return govy.NewRule(func(v *url.URL) error {
 		if err := validateURL(v); err != nil {
@@ -85,8 +109,13 @@ func URL(options ...URLOption) govy.Rule[*url.URL] {
 				Error:         err.Error(),
 			})
 		}
-		if vars, ok := validateURLOptions(v, ruleOptions); !ok {
-			return govy.NewRuleErrorTemplate(vars)
+		for _, option := range options {
+			if option == nil {
+				continue
+			}
+			if vars, ok := option.validate(v); !ok {
+				return govy.NewRuleErrorTemplate(vars)
+			}
 		}
 		return nil
 	}).
@@ -105,55 +134,6 @@ func validateURL(u *url.URL) error {
 		return errors.New("valid URL must contain either host, fragment or opaque data")
 	}
 	return nil
-}
-
-func newURLRuleOptions(options ...URLOption) urlRuleOptions {
-	var ruleOptions urlRuleOptions
-	for _, option := range options {
-		if option != nil {
-			option.apply(&ruleOptions)
-		}
-	}
-	return ruleOptions
-}
-
-func validateURLOptions(u *url.URL, options urlRuleOptions) (govy.TemplateVars, bool) {
-	if len(options.schemes) > 0 && !containsString(options.schemes, u.Scheme) {
-		return govy.TemplateVars{
-			PropertyValue:   u,
-			ComparisonValue: options.schemes,
-			Custom:          urlTemplateVars{Scheme: true},
-		}, false
-	}
-
-	hostname := u.Hostname()
-	if options.hostRequired && hostname == "" {
-		return govy.TemplateVars{
-			PropertyValue: u,
-			Custom:        urlTemplateVars{HostRequired: true},
-		}, false
-	}
-	if options.forbidUser && u.User != nil {
-		return govy.TemplateVars{
-			PropertyValue: u,
-			Custom:        urlTemplateVars{UserInfoForbidden: true},
-		}, false
-	}
-	if len(options.hostDenyList) > 0 && containsString(options.hostDenyList, hostname) {
-		return govy.TemplateVars{
-			PropertyValue:   u,
-			ComparisonValue: options.hostDenyList,
-			Custom:          urlTemplateVars{HostDenyList: true},
-		}, false
-	}
-	if len(options.hostAllowList) > 0 && !containsString(options.hostAllowList, hostname) {
-		return govy.TemplateVars{
-			PropertyValue:   u,
-			ComparisonValue: options.hostAllowList,
-			Custom:          urlTemplateVars{HostAllowList: true},
-		}, false
-	}
-	return govy.TemplateVars{}, true
 }
 
 func containsString(values []string, value string) bool {

--- a/pkg/rules/url.go
+++ b/pkg/rules/url.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"errors"
 	"net/url"
+	"strings"
 
 	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
@@ -71,7 +72,7 @@ func URLUserInfoForbidden() URLOption {
 func URLHostAllowList(hosts ...string) URLOption {
 	return urlOptionFunc(func(u *url.URL) (govy.TemplateVars, bool) {
 		hostname := u.Hostname()
-		if len(hosts) == 0 || containsString(hosts, hostname) {
+		if len(hosts) == 0 || containsStringFold(hosts, hostname) {
 			return govy.TemplateVars{}, true
 		}
 		return govy.TemplateVars{
@@ -86,7 +87,7 @@ func URLHostAllowList(hosts ...string) URLOption {
 func URLHostDenyList(hosts ...string) URLOption {
 	return urlOptionFunc(func(u *url.URL) (govy.TemplateVars, bool) {
 		hostname := u.Hostname()
-		if len(hosts) == 0 || !containsString(hosts, hostname) {
+		if len(hosts) == 0 || !containsStringFold(hosts, hostname) {
 			return govy.TemplateVars{}, true
 		}
 		return govy.TemplateVars{
@@ -139,6 +140,15 @@ func validateURL(u *url.URL) error {
 func containsString(values []string, value string) bool {
 	for _, v := range values {
 		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStringFold(values []string, value string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, value) {
 			return true
 		}
 	}

--- a/pkg/rules/url.go
+++ b/pkg/rules/url.go
@@ -3,15 +3,80 @@ package rules
 import (
 	"errors"
 	"net/url"
+	"slices"
 
 	"github.com/nobl9/govy/internal/messagetemplates"
 	"github.com/nobl9/govy/pkg/govy"
 )
 
+// URLOption configures additional checks for [URL].
+type URLOption interface {
+	apply(*urlRuleOptions)
+}
+
+type urlOptionFunc func(*urlRuleOptions)
+
+func (f urlOptionFunc) apply(options *urlRuleOptions) {
+	f(options)
+}
+
+type urlRuleOptions struct {
+	schemes       []string
+	hostRequired  bool
+	forbidUser    bool
+	hostAllowList []string
+	hostDenyList  []string
+}
+
+type urlTemplateVars struct {
+	Scheme            bool
+	HostRequired      bool
+	UserInfoForbidden bool
+	HostDenyList      bool
+	HostAllowList     bool
+}
+
+// URLSchemes restricts [URL] to the provided schemes.
+func URLSchemes(schemes ...string) URLOption {
+	return urlOptionFunc(func(options *urlRuleOptions) {
+		options.schemes = slices.Clone(schemes)
+	})
+}
+
+// URLHostRequired requires [URL] values to have a host.
+func URLHostRequired() URLOption {
+	return urlOptionFunc(func(options *urlRuleOptions) {
+		options.hostRequired = true
+	})
+}
+
+// URLUserInfoForbidden rejects [URL] values with user information.
+func URLUserInfoForbidden() URLOption {
+	return urlOptionFunc(func(options *urlRuleOptions) {
+		options.forbidUser = true
+	})
+}
+
+// URLHostAllowList restricts [URL] values to the provided hostnames.
+func URLHostAllowList(hosts ...string) URLOption {
+	return urlOptionFunc(func(options *urlRuleOptions) {
+		options.hostAllowList = slices.Clone(hosts)
+	})
+}
+
+// URLHostDenyList rejects [URL] values with the provided hostnames.
+// Denied entries take precedence over entries defined with [URLHostAllowList].
+func URLHostDenyList(hosts ...string) URLOption {
+	return urlOptionFunc(func(options *urlRuleOptions) {
+		options.hostDenyList = slices.Clone(hosts)
+	})
+}
+
 // URL ensures the URL is valid.
 // The URL must have a scheme (e.g. https://) and contain either host, fragment or opaque data.
-func URL() govy.Rule[*url.URL] {
+func URL(options ...URLOption) govy.Rule[*url.URL] {
 	tpl := messagetemplates.Get(messagetemplates.URLTemplate)
+	ruleOptions := newURLRuleOptions(options...)
 
 	return govy.NewRule(func(v *url.URL) error {
 		if err := validateURL(v); err != nil {
@@ -19,6 +84,9 @@ func URL() govy.Rule[*url.URL] {
 				PropertyValue: v,
 				Error:         err.Error(),
 			})
+		}
+		if vars, ok := validateURLOptions(v, ruleOptions); !ok {
+			return govy.NewRuleErrorTemplate(vars)
 		}
 		return nil
 	}).
@@ -37,4 +105,62 @@ func validateURL(u *url.URL) error {
 		return errors.New("valid URL must contain either host, fragment or opaque data")
 	}
 	return nil
+}
+
+func newURLRuleOptions(options ...URLOption) urlRuleOptions {
+	var ruleOptions urlRuleOptions
+	for _, option := range options {
+		if option != nil {
+			option.apply(&ruleOptions)
+		}
+	}
+	return ruleOptions
+}
+
+func validateURLOptions(u *url.URL, options urlRuleOptions) (govy.TemplateVars, bool) {
+	if len(options.schemes) > 0 && !containsString(options.schemes, u.Scheme) {
+		return govy.TemplateVars{
+			PropertyValue:   u,
+			ComparisonValue: options.schemes,
+			Custom:          urlTemplateVars{Scheme: true},
+		}, false
+	}
+
+	hostname := u.Hostname()
+	if options.hostRequired && hostname == "" {
+		return govy.TemplateVars{
+			PropertyValue: u,
+			Custom:        urlTemplateVars{HostRequired: true},
+		}, false
+	}
+	if options.forbidUser && u.User != nil {
+		return govy.TemplateVars{
+			PropertyValue: u,
+			Custom:        urlTemplateVars{UserInfoForbidden: true},
+		}, false
+	}
+	if len(options.hostDenyList) > 0 && containsString(options.hostDenyList, hostname) {
+		return govy.TemplateVars{
+			PropertyValue:   u,
+			ComparisonValue: options.hostDenyList,
+			Custom:          urlTemplateVars{HostDenyList: true},
+		}, false
+	}
+	if len(options.hostAllowList) > 0 && !containsString(options.hostAllowList, hostname) {
+		return govy.TemplateVars{
+			PropertyValue:   u,
+			ComparisonValue: options.hostAllowList,
+			Custom:          urlTemplateVars{HostAllowList: true},
+		}, false
+	}
+	return govy.TemplateVars{}, true
+}
+
+func containsString(values []string, value string) bool {
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/rules/url_test.go
+++ b/pkg/rules/url_test.go
@@ -108,6 +108,10 @@ func TestURL_WithOptions(t *testing.T) {
 			url:     "https://foobar.com",
 			options: []URLOption{URLHostAllowList("foobar.com")},
 		},
+		"host allow list accepts hostname with different case": {
+			url:     "https://FooBar.COM",
+			options: []URLOption{URLHostAllowList("foobar.com")},
+		},
 		"host allow list rejects unlisted hostname": {
 			url:         "https://barfoo.com",
 			options:     []URLOption{URLHostAllowList("foobar.com")},
@@ -120,6 +124,12 @@ func TestURL_WithOptions(t *testing.T) {
 		},
 		"host deny list rejects exact hostname": {
 			url:         "https://foobar.com",
+			options:     []URLOption{URLHostDenyList("foobar.com")},
+			expectedErr: "valid URL must not use any of the following hostnames: 'foobar.com'",
+			shouldFail:  true,
+		},
+		"host deny list rejects hostname with different case": {
+			url:         "https://FooBar.COM",
 			options:     []URLOption{URLHostDenyList("foobar.com")},
 			expectedErr: "valid URL must not use any of the following hostnames: 'foobar.com'",
 			shouldFail:  true,

--- a/pkg/rules/url_test.go
+++ b/pkg/rules/url_test.go
@@ -121,7 +121,7 @@ func TestURL_WithOptions(t *testing.T) {
 		"host deny list rejects exact hostname": {
 			url:         "https://foobar.com",
 			options:     []URLOption{URLHostDenyList("foobar.com")},
-			expectedErr: "valid URL must not use one of the following hostnames: 'foobar.com'",
+			expectedErr: "valid URL must not use any of the following hostnames: 'foobar.com'",
 			shouldFail:  true,
 		},
 		"host deny list accepts other hostnames": {
@@ -134,7 +134,7 @@ func TestURL_WithOptions(t *testing.T) {
 				URLHostAllowList("foobar.com"),
 				URLHostDenyList("foobar.com"),
 			},
-			expectedErr: "valid URL must not use one of the following hostnames: 'foobar.com'",
+			expectedErr: "valid URL must not use any of the following hostnames: 'foobar.com'",
 			shouldFail:  true,
 		},
 	}

--- a/pkg/rules/url_test.go
+++ b/pkg/rules/url_test.go
@@ -65,6 +65,97 @@ func TestURL(t *testing.T) {
 	}
 }
 
+func TestURL_WithOptions(t *testing.T) {
+	tests := map[string]struct {
+		url         string
+		options     []URLOption
+		expectedErr string
+		shouldFail  bool
+	}{
+		"scheme allowed": {
+			url:     "https://foobar.com",
+			options: []URLOption{URLSchemes("https")},
+		},
+		"scheme rejected": {
+			url:         "http://foobar.com",
+			options:     []URLOption{URLSchemes("https")},
+			expectedErr: "valid URL must use one of the following schemes: 'https'",
+			shouldFail:  true,
+		},
+		"host required allows host": {
+			url:     "https://foobar.com",
+			options: []URLOption{URLHostRequired()},
+		},
+		"host required rejects opaque": {
+			url:         "mailto:someone@example.com",
+			options:     []URLOption{URLHostRequired()},
+			expectedErr: "valid URL must have a host",
+			shouldFail:  true,
+		},
+		"host required rejects fragment only": {
+			url:         "https:#fragment",
+			options:     []URLOption{URLHostRequired()},
+			expectedErr: "valid URL must have a host",
+			shouldFail:  true,
+		},
+		"user info forbidden rejects user info": {
+			url:         "https://user@foobar.com",
+			options:     []URLOption{URLUserInfoForbidden()},
+			expectedErr: "valid URL must not contain user information",
+			shouldFail:  true,
+		},
+		"host allow list accepts exact hostname": {
+			url:     "https://foobar.com",
+			options: []URLOption{URLHostAllowList("foobar.com")},
+		},
+		"host allow list rejects unlisted hostname": {
+			url:         "https://barfoo.com",
+			options:     []URLOption{URLHostAllowList("foobar.com")},
+			expectedErr: "valid URL must use one of the following hostnames: 'foobar.com'",
+			shouldFail:  true,
+		},
+		"host allow list ignores port": {
+			url:     "https://foobar.com:8443",
+			options: []URLOption{URLHostAllowList("foobar.com")},
+		},
+		"host deny list rejects exact hostname": {
+			url:         "https://foobar.com",
+			options:     []URLOption{URLHostDenyList("foobar.com")},
+			expectedErr: "valid URL must not use one of the following hostnames: 'foobar.com'",
+			shouldFail:  true,
+		},
+		"host deny list accepts other hostnames": {
+			url:     "https://barfoo.com",
+			options: []URLOption{URLHostDenyList("foobar.com")},
+		},
+		"host deny list wins over allow list": {
+			url: "https://foobar.com",
+			options: []URLOption{
+				URLHostAllowList("foobar.com"),
+				URLHostDenyList("foobar.com"),
+			},
+			expectedErr: "valid URL must not use one of the following hostnames: 'foobar.com'",
+			shouldFail:  true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(tc.url)
+			assert.Require(t, assert.NoError(t, err))
+
+			err = URL(tc.options...).Validate(u)
+			if tc.shouldFail {
+				assert.Require(t, assert.Error(t, err))
+				assert.EqualError(t, err, tc.expectedErr)
+				assert.True(t, govy.HasErrorCode(err, ErrorCodeURL))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func BenchmarkURL(b *testing.B) {
 	parsedURLs := make([]*url.URL, 0, len(urlTestCases))
 	for _, tc := range urlTestCases {


### PR DESCRIPTION
## Motivation

Currently URL validation only checks for the most common errors, but often times there are other common checks users are forced to implement themselves. I think it would be worthwhile to extend the current `rules.URL` signature with opt-in options, which would verify additional properties of the URL.

## Summary

Support scheme, host, user info, and hostname allow/deny checks in the URL rule. Add targeted error messages and tests to cover the new validation behavior.

## Release Notes

Added configurable `rules.URL` validation options for enforcing allowed schemes, required hosts, disallowed user info, and hostname allow/deny lists. URL option failures now use built-in message templates so applications can customize or translate them consistently.