### PR TITLE
chore: support fork PR autolabeling

### DIFF
--- a/.github/workflows/pr-autolabeler.yml
+++ b/.github/workflows/pr-autolabeler.yml
@@ -1,0 +1,19 @@
+name: PR Autolabeler
+
+on:
+  # pull_request_target is required to label PRs from forks.
+  # This workflow must stay metadata-only: do not checkout or run PR code here.
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7.3.1
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,28 +4,11 @@ on:
   push:
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  # 'edited' event is required to account for initial invalid PR names
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
-
 permissions:
   contents: read
 
 jobs:
-  autolabeler:
-    if: github.event_name == 'pull_request'
-    permissions:
-      # write permission is required to add labels to pull requests
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter/autolabeler@v7.3.1
-        with:
-          token: ${{ secrets.RELEASE_LABELER_TOKEN }}
-
   update_release_draft:
-    if: github.event_name == 'push'
     permissions:
       # write permission is required to create a github release
       contents: write


### PR DESCRIPTION
## Motivation

External contributor PRs cannot access repository secrets, even after maintainers approve the workflow run. The Release Drafter autolabeler currently depends on PR-time release-drafter workflow execution, which makes fork PR labeling unreliable.

## Summary

- Move PR labeling into a separate metadata-only `pull_request_target` workflow.
- Use `github.token` for PR labels instead of repository secrets.
- Keep release draft updates restricted to `push` events on `main`.

## Related Changes

https://github.com/nobl9/nobl9-go/pull/937
