### PR TITLE
chore: clarify cascade mode inheritance and inclusion behavior

### DIFF
--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -1504,18 +1504,18 @@ func ExamplePropertyRules_When() {
 	//     - must not be equal to 'Jerry'
 }
 
-// To customize how directly associated [govy.Rule] instances are evaluated,
-// use [govy.PropertyRules.Cascade].
-// [govy.CascadeModeStop] stops validation after the first error,
-// while [govy.CascadeModeContinue] evaluates the remaining rules.
+// [govy.PropertyRules.Cascade] controls the property's rule and validator sequence.
+// [govy.CascadeModeStop] stops the sequence after the first [govy.Rule],
+// [govy.RuleSet], or included [govy.Validator] returns an error.
+// [govy.CascadeModeContinue] continues the sequence after errors.
 //
-// The mode applies only to the given [govy.PropertyRules].
-// It does not affect the containing [govy.Validator], neighboring property rules,
-// the internal evaluation of a [govy.RuleSet] added with [govy.PropertyRules.Rules],
-// or a [govy.Validator] added with [govy.PropertyRules.Include].
+// Each [govy.RuleSet] uses its own mode to evaluate its rules.
+// Each included [govy.Validator] uses its own mode to evaluate its properties.
+// The property mode does not affect the containing validator or sibling
+// properties.
 //
-// An explicitly configured property mode takes precedence over a mode inherited
-// from the containing validator.
+// A property mode set explicitly takes precedence over the containing
+// validator's mode.
 // See [ExampleValidator_Cascade] for an example of this precedence.
 func ExamplePropertyRules_Cascade() {
 	alwaysFailingRule := govy.NewRule(func(string) error {
@@ -1583,14 +1583,14 @@ func ExampleValidator_ValidateSlice() {
 	//     - always fails
 }
 
-// Unlike [govy.PropertyRules.Cascade], [govy.Validator.Cascade] controls whether
-// validation continues with the next direct property after a property fails.
-// It also propagates the mode to each direct property whose cascade mode
-// has not been explicitly set.
+// [govy.Validator.Cascade] controls whether validation continues to the
+// next property after a property returns an error.
+// It also sets the mode on each property that has no explicit mode.
 //
 // A mode explicitly set with [govy.PropertyRules.Cascade] takes precedence.
-// The validator mode does not propagate into validators added through Include methods;
-// configure each included validator directly with [govy.Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change an included validator's mode, call [govy.Validator.Cascade]
+// before you pass the validator to an Include method.
 //
 // See [ExamplePropertyRules_Cascade] for more details on [govy.PropertyRules.Cascade].
 func ExampleValidator_Cascade() {

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -1504,13 +1504,19 @@ func ExamplePropertyRules_When() {
 	//     - must not be equal to 'Jerry'
 }
 
-// To customize how [govy.Rule] are evaluated use [govy.PropertyRules.Cascade].
-// Use [govy.CascadeModeStop] to stop validation after the first error.
-// If you wish to revert to the default behavior, use [govy.CascadeModeContinue].
+// To customize how directly associated [govy.Rule] instances are evaluated,
+// use [govy.PropertyRules.Cascade].
+// [govy.CascadeModeStop] stops validation after the first error,
+// while [govy.CascadeModeContinue] evaluates the remaining rules.
 //
-// Note: the cascade mode change only applies to the given [govy.PropertyRules] instance
-// and not the parent [govy.Validator] or neighboring [govy.PropertyRules].
-// It does however override the [govy.CascadeMode] set for [govy.Validator].
+// The mode applies only to the given [govy.PropertyRules].
+// It does not affect the containing [govy.Validator], neighboring property rules,
+// the internal evaluation of a [govy.RuleSet] added with [govy.PropertyRules.Rules],
+// or a [govy.Validator] added with [govy.PropertyRules.Include].
+//
+// An explicitly configured property mode takes precedence over a mode inherited
+// from the containing validator.
+// See [ExampleValidator_Cascade] for an example of this precedence.
 func ExamplePropertyRules_Cascade() {
 	alwaysFailingRule := govy.NewRule(func(string) error {
 		return fmt.Errorf("always fails")
@@ -1577,12 +1583,14 @@ func ExampleValidator_ValidateSlice() {
 	//     - always fails
 }
 
-// Unlike [govy.PropertyRules.Cascade] which works on [govy.PropertyRules] level,
-// [govy.Validator.Cascade] propagates to all the properties of [govy.Validator] and
-// furthermore, will stop evaluating the next property if any preceding property fails.
+// Unlike [govy.PropertyRules.Cascade], [govy.Validator.Cascade] controls whether
+// validation continues with the next direct property after a property fails.
+// It also propagates the mode to each direct property whose cascade mode
+// has not been explicitly set.
 //
-// If [govy.PropertyRules.Cascade] is set, the setting will take precedence over
-// [govy.Validator] cascade mode.
+// A mode explicitly set with [govy.PropertyRules.Cascade] takes precedence.
+// The validator mode does not propagate into validators added through Include methods;
+// configure each included validator directly with [govy.Validator.Cascade].
 //
 // See [ExamplePropertyRules_Cascade] for more details on [govy.PropertyRules.Cascade].
 func ExampleValidator_Cascade() {
@@ -2035,7 +2043,7 @@ func ExampleInferPathModeGenerate() {
 	govyconfig.SetInferredPath(govyconfig.InferredPath{
 		Path: jsonpath.New().Name("name"),
 		File: "pkg/govy/example_test.go",
-		Line: 2042,
+		Line: 2050,
 	})
 
 	v2 := govy.New(

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -201,8 +201,8 @@ func (r PropertyRules[T, P]) Rules(rules ...RulesInterface[T]) PropertyRules[T, 
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
-// Included validators retain their own cascade modes;
-// configure them directly with [Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change a mode, call [Validator.Cascade] before you pass the validator to this method.
 func (r PropertyRules[T, P]) Include(rules ...ValidatorInterface[T]) PropertyRules[T, P] {
 	for _, rule := range rules {
 		r.rules = append(r.rules, rule)
@@ -238,13 +238,14 @@ func (r PropertyRules[T, P]) HideValue() PropertyRules[T, P] {
 	return r
 }
 
-// Cascade sets the [CascadeMode] for rules directly associated with the property.
-// Each [RuleSet] added with [PropertyRules.Rules] and each [Validator] added with
-// [PropertyRules.Include] controls its own internal cascade independently.
+// Cascade sets the [CascadeMode] for the property's rules and included validators.
+// [CascadeModeStop] stops after the first [Rule], [RuleSet], or included
+// [Validator] returns an error.
+// Each [RuleSet] uses its own cascade mode internally.
+// Each included [Validator] also uses its own cascade mode internally.
 //
-// The mode does not affect the containing [Validator] or sibling property rules.
-// When set explicitly, it takes precedence over the mode inherited from
-// the containing [Validator].
+// The mode does not affect the containing [Validator] or sibling properties.
+// An explicit property mode takes precedence over the containing validator's mode.
 func (r PropertyRules[T, P]) Cascade(mode CascadeMode) PropertyRules[T, P] {
 	r.cascadeMode = mode
 	return r

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -201,6 +201,8 @@ func (r PropertyRules[T, P]) Rules(rules ...RulesInterface[T]) PropertyRules[T, 
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
+// Included validators retain their own cascade modes;
+// configure them directly with [Validator.Cascade].
 func (r PropertyRules[T, P]) Include(rules ...ValidatorInterface[T]) PropertyRules[T, P] {
 	for _, rule := range rules {
 		r.rules = append(r.rules, rule)
@@ -236,8 +238,13 @@ func (r PropertyRules[T, P]) HideValue() PropertyRules[T, P] {
 	return r
 }
 
-// Cascade sets the [CascadeMode] for the property,
-// which controls the flow of evaluating the validation rules.
+// Cascade sets the [CascadeMode] for rules directly associated with the property.
+// Each [RuleSet] added with [PropertyRules.Rules] and each [Validator] added with
+// [PropertyRules.Include] controls its own internal cascade independently.
+//
+// The mode does not affect the containing [Validator] or sibling property rules.
+// When set explicitly, it takes precedence over the mode inherited from
+// the containing [Validator].
 func (r PropertyRules[T, P]) Cascade(mode CascadeMode) PropertyRules[T, P] {
 	r.cascadeMode = mode
 	return r

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -156,6 +156,8 @@ func (r PropertyRulesForMap[M, K, V, P]) When(
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
+// Included validators retain their own cascade modes;
+// configure them directly with [Validator.Cascade].
 func (r PropertyRulesForMap[M, K, V, P]) Include(
 	validators ...ValidatorInterface[M],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -164,6 +166,8 @@ func (r PropertyRulesForMap[M, K, V, P]) Include(
 }
 
 // IncludeForKeys associates specified [Validator] and its [PropertyRules] with map's keys.
+// Included validators retain their own cascade modes;
+// configure them directly with [Validator.Cascade].
 func (r PropertyRulesForMap[M, K, V, P]) IncludeForKeys(
 	validators ...ValidatorInterface[K],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -172,6 +176,8 @@ func (r PropertyRulesForMap[M, K, V, P]) IncludeForKeys(
 }
 
 // IncludeForValues associates specified [Validator] and its [PropertyRules] with map's values.
+// Included validators retain their own cascade modes;
+// configure them directly with [Validator.Cascade].
 func (r PropertyRulesForMap[M, K, V, P]) IncludeForValues(
 	rules ...ValidatorInterface[V],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -181,6 +187,8 @@ func (r PropertyRulesForMap[M, K, V, P]) IncludeForValues(
 
 // IncludeForItems associates specified [Validator] and its [PropertyRules] with [MapItem].
 // It allows validating both key and value in conjunction.
+// Included validators retain their own cascade modes;
+// configure them directly with [Validator.Cascade].
 func (r PropertyRulesForMap[M, K, V, P]) IncludeForItems(
 	rules ...ValidatorInterface[MapItem[K, V]],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -188,7 +196,12 @@ func (r PropertyRulesForMap[M, K, V, P]) IncludeForItems(
 	return r
 }
 
-// Cascade => refer to [PropertyRules.Cascade] documentation.
+// Cascade sets the [CascadeMode] for rules associated with the whole map,
+// its keys, its values, and its key-value pairs.
+// It does not propagate into validators added with any Include method.
+//
+// When set explicitly, the mode takes precedence over the mode inherited from
+// the containing [Validator].
 func (r PropertyRulesForMap[M, K, V, P]) Cascade(mode CascadeMode) PropertyRulesForMap[M, K, V, P] {
 	r.cascadeMode = mode
 	r.mapRules = r.mapRules.Cascade(mode)

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -156,8 +156,8 @@ func (r PropertyRulesForMap[M, K, V, P]) When(
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
-// Included validators retain their own cascade modes;
-// configure them directly with [Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change a mode, call [Validator.Cascade] before you pass the validator to this method.
 func (r PropertyRulesForMap[M, K, V, P]) Include(
 	validators ...ValidatorInterface[M],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -166,8 +166,8 @@ func (r PropertyRulesForMap[M, K, V, P]) Include(
 }
 
 // IncludeForKeys associates specified [Validator] and its [PropertyRules] with map's keys.
-// Included validators retain their own cascade modes;
-// configure them directly with [Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change a mode, call [Validator.Cascade] before you pass the validator to this method.
 func (r PropertyRulesForMap[M, K, V, P]) IncludeForKeys(
 	validators ...ValidatorInterface[K],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -176,8 +176,8 @@ func (r PropertyRulesForMap[M, K, V, P]) IncludeForKeys(
 }
 
 // IncludeForValues associates specified [Validator] and its [PropertyRules] with map's values.
-// Included validators retain their own cascade modes;
-// configure them directly with [Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change a mode, call [Validator.Cascade] before you pass the validator to this method.
 func (r PropertyRulesForMap[M, K, V, P]) IncludeForValues(
 	rules ...ValidatorInterface[V],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -187,8 +187,8 @@ func (r PropertyRulesForMap[M, K, V, P]) IncludeForValues(
 
 // IncludeForItems associates specified [Validator] and its [PropertyRules] with [MapItem].
 // It allows validating both key and value in conjunction.
-// Included validators retain their own cascade modes;
-// configure them directly with [Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change a mode, call [Validator.Cascade] before you pass the validator to this method.
 func (r PropertyRulesForMap[M, K, V, P]) IncludeForItems(
 	rules ...ValidatorInterface[MapItem[K, V]],
 ) PropertyRulesForMap[M, K, V, P] {
@@ -196,12 +196,14 @@ func (r PropertyRulesForMap[M, K, V, P]) IncludeForItems(
 	return r
 }
 
-// Cascade sets the [CascadeMode] for rules associated with the whole map,
-// its keys, its values, and its key-value pairs.
-// It does not propagate into validators added with any Include method.
+// Cascade sets the [CascadeMode] for rules that validate the whole map,
+// each key, each value, and each [MapItem].
+// If whole-map validation returns an error, [CascadeModeStop] skips all entries.
+// The key, value, and [MapItem] rule groups apply the mode independently.
+// An entry error does not stop validation of other entries.
 //
-// When set explicitly, the mode takes precedence over the mode inherited from
-// the containing [Validator].
+// Each included [Validator] uses its own cascade mode internally.
+// An explicit map mode takes precedence over the containing validator's mode.
 func (r PropertyRulesForMap[M, K, V, P]) Cascade(mode CascadeMode) PropertyRulesForMap[M, K, V, P] {
 	r.cascadeMode = mode
 	r.mapRules = r.mapRules.Cascade(mode)

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -106,18 +106,28 @@ func (r PropertyRulesForSlice[S, T, P]) When(
 }
 
 // IncludeForEach associates specified [Validator] and its [PropertyRules] with each element of the slice.
+// Included validators retain their own cascade modes;
+// configure them directly with [Validator.Cascade].
 func (r PropertyRulesForSlice[S, T, P]) IncludeForEach(rules ...ValidatorInterface[T]) PropertyRulesForSlice[S, T, P] {
 	r.forEachRules = r.forEachRules.Include(rules...)
 	return r
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
+// Included validators retain their own cascade modes;
+// configure them directly with [Validator.Cascade].
 func (r PropertyRulesForSlice[S, T, P]) Include(rules ...ValidatorInterface[S]) PropertyRulesForSlice[S, T, P] {
 	r.sliceRules = r.sliceRules.Include(rules...)
 	return r
 }
 
-// Cascade => refer to [PropertyRules.Cascade] documentation.
+// Cascade sets the [CascadeMode] for rules associated with the whole slice
+// and for rules associated with each element.
+// It does not propagate into validators added with
+// [PropertyRulesForSlice.Include] or [PropertyRulesForSlice.IncludeForEach].
+//
+// When set explicitly, the mode takes precedence over the mode inherited from
+// the containing [Validator].
 func (r PropertyRulesForSlice[S, T, P]) Cascade(mode CascadeMode) PropertyRulesForSlice[S, T, P] {
 	r.cascadeMode = mode
 	r.sliceRules = r.sliceRules.Cascade(mode)

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -106,28 +106,29 @@ func (r PropertyRulesForSlice[S, T, P]) When(
 }
 
 // IncludeForEach associates specified [Validator] and its [PropertyRules] with each element of the slice.
-// Included validators retain their own cascade modes;
-// configure them directly with [Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change a mode, call [Validator.Cascade] before you pass the validator to this method.
 func (r PropertyRulesForSlice[S, T, P]) IncludeForEach(rules ...ValidatorInterface[T]) PropertyRulesForSlice[S, T, P] {
 	r.forEachRules = r.forEachRules.Include(rules...)
 	return r
 }
 
 // Include embeds specified [Validator] and its [PropertyRules] into the property.
-// Included validators retain their own cascade modes;
-// configure them directly with [Validator.Cascade].
+// Included validators use their own cascade modes.
+// To change a mode, call [Validator.Cascade] before you pass the validator to this method.
 func (r PropertyRulesForSlice[S, T, P]) Include(rules ...ValidatorInterface[S]) PropertyRulesForSlice[S, T, P] {
 	r.sliceRules = r.sliceRules.Include(rules...)
 	return r
 }
 
-// Cascade sets the [CascadeMode] for rules associated with the whole slice
-// and for rules associated with each element.
-// It does not propagate into validators added with
-// [PropertyRulesForSlice.Include] or [PropertyRulesForSlice.IncludeForEach].
+// Cascade sets the [CascadeMode] for rules that validate the whole slice
+// and each element.
+// If whole-slice validation returns an error, [CascadeModeStop] skips all elements.
+// The mode applies separately to the rules for each element.
+// An element error does not stop validation of later elements.
 //
-// When set explicitly, the mode takes precedence over the mode inherited from
-// the containing [Validator].
+// Each included [Validator] uses its own cascade mode internally.
+// An explicit slice mode takes precedence over the containing validator's mode.
 func (r PropertyRulesForSlice[S, T, P]) Cascade(mode CascadeMode) PropertyRulesForSlice[S, T, P] {
 	r.cascadeMode = mode
 	r.sliceRules = r.sliceRules.Cascade(mode)

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -44,8 +44,13 @@ func (v Validator[T]) When(predicate Predicate[T], opts ...WhenOption) Validator
 	return v
 }
 
-// Cascade sets the [CascadeMode] for the validator,
-// which controls the flow of evaluating the validation rules.
+// Cascade sets the [CascadeMode] for the validator.
+// The mode controls whether validation continues with the next property after
+// a property fails and is inherited by each direct property whose cascade mode
+// has not been explicitly set.
+//
+// Validators added through Include methods retain their own cascade modes.
+// Call [Validator.Cascade] on an included validator to configure it.
 func (v Validator[T]) Cascade(mode CascadeMode) Validator[T] {
 	v.cascadeMode = mode
 	props := make([]PropertyRulesInterface[T], 0, len(v.props))

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -45,12 +45,12 @@ func (v Validator[T]) When(predicate Predicate[T], opts ...WhenOption) Validator
 }
 
 // Cascade sets the [CascadeMode] for the validator.
-// The mode controls whether validation continues with the next property after
-// a property fails and is inherited by each direct property whose cascade mode
-// has not been explicitly set.
+// [CascadeModeStop] stops validation after the first property returns an error.
+// The method also sets the mode on each property that has no explicit mode.
 //
-// Validators added through Include methods retain their own cascade modes.
-// Call [Validator.Cascade] on an included validator to configure it.
+// Included validators use their own cascade modes.
+// To change an included validator's mode, call [Validator.Cascade] before you
+// pass the validator to an Include method.
 func (v Validator[T]) Cascade(mode CascadeMode) Validator[T] {
 	v.cascadeMode = mode
 	props := make([]PropertyRulesInterface[T], 0, len(v.props))

--- a/pkg/govy/validator_test.go
+++ b/pkg/govy/validator_test.go
@@ -234,6 +234,14 @@ func TestValidatorCascade(t *testing.T) {
 		propertyRulesForSlice,
 		propertyRulesForMap,
 	)
+	includedValidator := govy.New(
+		govy.For(func(m mockValidatorStruct) string { return "test" }).
+			WithName("first").
+			Rules(govy.NewRule(func(v string) error { return errors.New("1") })),
+		govy.For(func(m mockValidatorStruct) string { return "test" }).
+			WithName("second").
+			Rules(govy.NewRule(func(v string) error { return errors.New("2") })),
+	)
 
 	allErrors := []govytest.ExpectedRuleError{
 		{PropertyPath: "string", Message: "1"},
@@ -306,6 +314,17 @@ func TestValidatorCascade(t *testing.T) {
 			[]govytest.ExpectedRuleError{
 				{PropertyPath: "string", Message: "1"},
 				{PropertyPath: "string", Message: "2"},
+			},
+		},
+		"included validator retains default mode": {
+			govy.New(
+				govy.For(govy.GetSelf[mockValidatorStruct]()).
+					WithName("included").
+					Include(includedValidator),
+			).Cascade(govy.CascadeModeStop),
+			[]govytest.ExpectedRuleError{
+				{PropertyPath: "included.first", Message: "1"},
+				{PropertyPath: "included.second", Message: "2"},
 			},
 		},
 	}
@@ -538,7 +557,7 @@ func TestValidatorInferPath(t *testing.T) {
 			// Changed name to differentiate between runtime and generate modes.
 			Path: jsonpath.New().Name("generated-students"),
 			File: "pkg/govy/validator_test.go",
-			Line: 551,
+			Line: 570,
 		})
 
 		v := govy.New(


### PR DESCRIPTION
Update API documentation and examples to describe cascade precedence and ensure included validators retain their own cascade modes.
