### PR TITLE
feat: add validation options for hiding sensitive values

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -52,43 +52,50 @@ func PropertyValueString(v any) string {
 	if v == nil {
 		return ""
 	}
-	rv := reflect.ValueOf(v)
-	ft := reflect.Indirect(rv)
+
+	// Fast, refelection-free path.
 	var s string
-	switch ft.Kind() {
-	case reflect.Interface, reflect.Map, reflect.Slice:
-		if rv.IsZero() {
-			break
-		}
-		raw, _ := json.Marshal(v)
-		s = string(raw)
-	case reflect.Struct:
-		// If the struct is empty and it has.
-		if rv.IsZero() && rv.NumField() != 0 {
-			break
-		}
-		if timeDate, ok := v.(time.Time); ok {
-			s = timeDate.Format(time.RFC3339)
-			break
-		}
-		if stringer, ok := v.(fmt.Stringer); ok && !hasJSONTags(v, rv.Kind() == reflect.Pointer) {
-			s = stringer.String()
-			break
-		}
-		raw, _ := json.Marshal(v)
-		s = string(raw)
-	case reflect.Pointer:
-		if rv.IsNil() {
-			return ""
-		}
-		deref := rv.Elem().Interface()
-		return PropertyValueString(deref)
-	case reflect.Func:
-		return "func"
-	case reflect.Invalid:
-		return ""
+	switch v := v.(type) {
+	case string:
+		s = v
 	default:
-		s = fmt.Sprint(ft.Interface())
+		rv := reflect.ValueOf(v)
+		ft := reflect.Indirect(rv)
+		switch ft.Kind() {
+		case reflect.Interface, reflect.Map, reflect.Slice:
+			if rv.IsZero() {
+				break
+			}
+			raw, _ := json.Marshal(v)
+			s = string(raw)
+		case reflect.Struct:
+			// If the struct is empty and it has.
+			if rv.IsZero() && rv.NumField() != 0 {
+				break
+			}
+			if timeDate, ok := v.(time.Time); ok {
+				s = timeDate.Format(time.RFC3339)
+				break
+			}
+			if stringer, ok := v.(fmt.Stringer); ok && !hasJSONTags(v, rv.Kind() == reflect.Pointer) {
+				s = stringer.String()
+				break
+			}
+			raw, _ := json.Marshal(v)
+			s = string(raw)
+		case reflect.Pointer:
+			if rv.IsNil() {
+				return ""
+			}
+			deref := rv.Elem().Interface()
+			return PropertyValueString(deref)
+		case reflect.Func:
+			return "func"
+		case reflect.Invalid:
+			return ""
+		default:
+			s = fmt.Sprint(ft.Interface())
+		}
 	}
 	s = limitString(s, 100)
 	s = strings.TrimSpace(s)

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -49,11 +49,21 @@ var newLineReplacer = strings.NewReplacer("\n", "\\n", "\r", "\\r")
 //
 // If a value is a struct of type [time.Time] it will be formatted using [time.RFC3339] layout.
 func PropertyValueString(v any) string {
+	return propertyValueString(v, 100)
+}
+
+// PropertyValueStringForRedaction returns the untruncated string representation
+// used to remove sensitive property values from messages.
+func PropertyValueStringForRedaction(v any) string {
+	return propertyValueString(v, 0)
+}
+
+func propertyValueString(v any, maxLength int) string {
 	if v == nil {
 		return ""
 	}
 
-	// Fast, refelection-free path.
+	// Fast, reflection-free path.
 	var s string
 	switch v := v.(type) {
 	case string:
@@ -88,7 +98,7 @@ func PropertyValueString(v any) string {
 				return ""
 			}
 			deref := rv.Elem().Interface()
-			return PropertyValueString(deref)
+			return propertyValueString(deref, maxLength)
 		case reflect.Func:
 			return "func"
 		case reflect.Invalid:
@@ -97,7 +107,9 @@ func PropertyValueString(v any) string {
 			s = fmt.Sprint(ft.Interface())
 		}
 	}
-	s = limitString(s, 100)
+	if maxLength > 0 {
+		s = limitString(s, maxLength)
+	}
 	s = strings.TrimSpace(s)
 	s = newLineReplacer.Replace(s)
 	return s

--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -94,14 +94,6 @@ func (e PropertyErrors) Error() string {
 	return b.String()
 }
 
-// HideValue hides the property value from each of the [PropertyError].
-func (e PropertyErrors) HideValue() PropertyErrors {
-	for _, err := range e {
-		_ = err.HideValue()
-	}
-	return e
-}
-
 // sort should be always called after aggregate.
 func (e PropertyErrors) sort() PropertyErrors {
 	if len(e) == 0 {
@@ -200,16 +192,6 @@ func (e *PropertyError) Equal(cmp *PropertyError) bool {
 		e.IsSliceElementError == cmp.IsSliceElementError
 }
 
-// HideValue hides the property value from each of the [PropertyError.Errors].
-func (e *PropertyError) HideValue() *PropertyError {
-	sv := internal.PropertyValueString(e.PropertyValue)
-	e.PropertyValue = ""
-	for _, err := range e.Errors {
-		_ = err.HideValue(sv)
-	}
-	return e
-}
-
 func (e *PropertyError) prependParentPropertyPath(path jsonpath.Path) *PropertyError {
 	e.PropertyPath = path.Join(e.PropertyPath)
 	return e
@@ -243,16 +225,6 @@ func (r *RuleError) Error() string {
 // See [ErrorCode.Add] for more details.
 func (r *RuleError) AddCode(code ErrorCode) *RuleError {
 	r.Code = r.Code.Add(code)
-	return r
-}
-
-// HideValue replaces all occurrences of stringValue in [RuleError.Message] with `[hidden]`.
-// If stringValue is empty or contains only Unicode whitespace, it leaves the message unchanged.
-func (r *RuleError) HideValue(stringValue string) *RuleError {
-	if strings.TrimSpace(stringValue) == "" {
-		return r
-	}
-	r.Message = strings.ReplaceAll(r.Message, stringValue, hiddenValue)
 	return r
 }
 

--- a/pkg/govy/errors.go
+++ b/pkg/govy/errors.go
@@ -266,8 +266,11 @@ func (e RuleErrorTemplate) Error() string {
 	return fmt.Sprintf("%T should not be used directly", e)
 }
 
-// TemplateVars lists all the possible variables that can be used by builtin rules' message templates.
-// Reuse the variable names to keep the consistency across all the rules.
+// TemplateVars lists variables available to builtin rule message templates.
+// Use the same names for consistent behavior across rules.
+// When [PropertyRules.HideValue] applies, it sets [TemplateVars.PropertyValue] to `[hidden]`
+// and redacts the property value from [TemplateVars.Error] before template execution.
+// It does not change the other fields.
 type TemplateVars struct {
 	// Common variables which are available for all the rules.
 	PropertyValue any

--- a/pkg/govy/hide_value_test.go
+++ b/pkg/govy/hide_value_test.go
@@ -15,44 +15,50 @@ import (
 	"github.com/nobl9/govy/pkg/rules"
 )
 
-func TestRule_HideValue(t *testing.T) {
+func TestPropertyRules_HideValue_RuleErrors(t *testing.T) {
 	const secret = "secret"
-
-	t.Run("plain error", func(t *testing.T) {
-		rule := govy.NewRule(func(v string) error {
-			return fmt.Errorf("invalid value %q", v)
-		})
-		hiddenRule := rule.HideValue()
-
-		assert.EqualError(t, rule.Validate(secret), `invalid value "secret"`)
-		assert.EqualError(t, hiddenRule.Validate(secret), `invalid value "[hidden]"`)
-		assert.EqualError(t, rule.Validate(secret), `invalid value "secret"`)
-	})
 
 	t.Run("long repeated value", func(t *testing.T) {
 		longSecret := strings.Repeat("sensitive-value-", 8)
 		rule := govy.NewRule(func(v string) error {
 			return fmt.Errorf("invalid values %q and %q", v, v)
-		}).HideValue()
+		})
 
-		assert.EqualError(t, rule.Validate(longSecret), `invalid values "[hidden]" and "[hidden]"`)
+		propErr := assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(rule).Validate(longSecret),
+			"property",
+			`invalid values "[hidden]" and "[hidden]"`,
+		)
+		assertDoesNotContainSecret(t, propErr, longSecret)
 	})
 
 	t.Run("truncated long value", func(t *testing.T) {
 		longSecret := strings.Repeat("sensitive-value-", 8)
 		rule := govy.NewRule(func(v string) error {
 			return fmt.Errorf("invalid value %q", v[:100]+"...")
-		}).HideValue()
+		})
 
-		assert.EqualError(t, rule.Validate(longSecret), `invalid value "[hidden]"`)
+		propErr := assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(rule).Validate(longSecret),
+			"property",
+			`invalid value "[hidden]"`,
+		)
+		assertDoesNotContainSecret(t, propErr, longSecret)
 	})
 
 	t.Run("non-string value", func(t *testing.T) {
 		rule := govy.NewRule(func(v int) error {
 			return fmt.Errorf("invalid value %d", v)
-		}).HideValue()
+		})
 
-		assert.EqualError(t, rule.Validate(42), "invalid value [hidden]")
+		_ = assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(rule).Validate(42),
+			"property",
+			"invalid value [hidden]",
+		)
 	})
 
 	t.Run("message template", func(t *testing.T) {
@@ -61,10 +67,14 @@ func TestRule_HideValue(t *testing.T) {
 				Error: fmt.Sprintf("nested error for %q", v),
 			})
 		}).
-			WithMessageTemplateString("{{ .PropertyValue }}: {{ .Error }}").
-			HideValue()
+			WithMessageTemplateString("{{ .PropertyValue }}: {{ .Error }}")
 
-		assert.EqualError(t, rule.Validate(secret), `[hidden]: nested error for "[hidden]"`)
+		_ = assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(rule).Validate(secret),
+			"property",
+			`[hidden]: nested error for "[hidden]"`,
+		)
 	})
 
 	t.Run("message template metadata", func(t *testing.T) {
@@ -78,12 +88,12 @@ func TestRule_HideValue(t *testing.T) {
 			WithExamples(secret).
 			WithMessageTemplateString(
 				"{{ .PropertyValue }}: {{ .Error }}; {{ .Details }}; {{ index .Examples 0 }}; {{ .Custom }}",
-			).
-			HideValue()
+			)
 
-		assert.EqualError(
+		_ = assertHiddenPropertyError(
 			t,
-			rule.Validate(secret),
+			hiddenPropertyRules(rule).Validate(secret),
+			"property",
 			`[hidden]: nested error for "[hidden]"; details for "[hidden]"; [hidden]; custom value "[hidden]"`,
 		)
 	})
@@ -94,12 +104,12 @@ func TestRule_HideValue(t *testing.T) {
 		}).
 			WithMessage(fmt.Sprintf("invalid value %q", secret)).
 			WithDetails(fmt.Sprintf("details for %q", secret)).
-			WithExamples(secret).
-			HideValue()
+			WithExamples(secret)
 
-		assert.EqualError(
+		_ = assertHiddenPropertyError(
 			t,
-			rule.Validate(secret),
+			hiddenPropertyRules(rule).Validate(secret),
+			"property",
 			`invalid value "[hidden]" (e.g. '[hidden]'); details for "[hidden]"`,
 		)
 	})
@@ -109,14 +119,19 @@ func TestRule_HideValue(t *testing.T) {
 			return govy.NewRuleError(fmt.Sprintf("invalid value %q", v), "inner")
 		}).
 			WithErrorCode("outer").
-			WithDescription("validation description").
-			HideValue()
+			WithDescription("validation description")
 
+		propErr := assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(rule).Validate(secret),
+			"property",
+			`invalid value "[hidden]"`,
+		)
 		assert.Equal(t, &govy.RuleError{
 			Message:     `invalid value "[hidden]"`,
 			Code:        "outer:inner",
 			Description: "validation description",
-		}, rule.Validate(secret))
+		}, propErr.Errors[0])
 	})
 
 	t.Run("structured rule error with configured message", func(t *testing.T) {
@@ -127,14 +142,19 @@ func TestRule_HideValue(t *testing.T) {
 			WithDetails(fmt.Sprintf("details for %q", secret)).
 			WithExamples(secret).
 			WithErrorCode("outer").
-			WithDescription("validation description").
-			HideValue()
+			WithDescription("validation description")
 
+		propErr := assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(rule).Validate(secret),
+			"property",
+			`invalid value "[hidden]" (e.g. '[hidden]'); details for "[hidden]"`,
+		)
 		assert.Equal(t, &govy.RuleError{
 			Message:     `invalid value "[hidden]" (e.g. '[hidden]'); details for "[hidden]"`,
 			Code:        "outer:inner",
 			Description: "validation description",
-		}, rule.Validate(secret))
+		}, propErr.Errors[0])
 	})
 
 	t.Run("structured property error without property value", func(t *testing.T) {
@@ -144,33 +164,41 @@ func TestRule_HideValue(t *testing.T) {
 				nil,
 				govy.NewRuleError(fmt.Sprintf("invalid value %q", v)),
 			)
-		}).HideValue()
+		})
 
-		err := mustErrorType[*govy.PropertyError](t, rule.Validate(secret))
+		err := mustPropertyErrors(t, hiddenPropertyRules(rule).Validate(secret))
+		assert.Require(t, assert.Len(t, err, 1))
 		assert.Equal(t, &govy.PropertyError{
-			PropertyPath: jsonpath.Parse("nested"),
+			PropertyPath: jsonpath.Parse("property.nested"),
 			Errors:       []*govy.RuleError{{Message: `invalid value "[hidden]"`}},
-		}, err)
-		assertDoesNotContainSecret(t, err, secret)
+		}, err[0])
+		assertDoesNotContainSecret(t, err[0], secret)
 	})
 
 	t.Run("pointer conversion", func(t *testing.T) {
 		rule := govy.NewRule(func(v string) error {
 			return fmt.Errorf("invalid value %q", v)
-		}).HideValue()
+		})
 
-		assert.EqualError(t, govy.RuleToPointer(rule).Validate(ptr(secret)), `invalid value "[hidden]"`)
+		_ = assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(govy.RuleToPointer(rule)).Validate(ptr(secret)),
+			"property",
+			`invalid value "[hidden]"`,
+		)
 	})
 
 	t.Run("rule set pointer conversion", func(t *testing.T) {
 		ruleSet := govy.NewRuleSet(govy.NewRule(func(v string) error {
 			return fmt.Errorf("invalid value %q", v)
-		}).HideValue())
+		}))
 
-		err := govy.RuleSetToPointer(ruleSet).Validate(ptr(secret))
-		errs := mustErrorType[govy.RuleSetError](t, err)
-		assert.Require(t, assert.Len(t, errs, 1))
-		assert.EqualError(t, errs[0], `invalid value "[hidden]"`)
+		_ = assertHiddenPropertyError(
+			t,
+			hiddenPropertyRules(govy.RuleSetToPointer(ruleSet)).Validate(ptr(secret)),
+			"property",
+			`invalid value "[hidden]"`,
+		)
 	})
 }
 
@@ -229,22 +257,6 @@ func TestPropertyRules_HideValue(t *testing.T) {
 				assert.EqualError(t, err, "- 'password':\n  - string must not be empty")
 			})
 		}
-	})
-
-	t.Run("rule-only scope", func(t *testing.T) {
-		propertyRules := govy.For(govy.GetSelf[string]()).
-			WithName("password").
-			Rules(govy.NewRule(func(v string) error {
-				return fmt.Errorf("invalid value %q", v)
-			}).HideValue())
-
-		errs := mustPropertyErrors(t, propertyRules.Validate(secret))
-		assert.Require(t, assert.Len(t, errs, 1))
-		assert.Equal(t, &govy.PropertyError{
-			PropertyPath:  jsonpath.Parse("password"),
-			PropertyValue: secret,
-			Errors:        []*govy.RuleError{{Message: `invalid value "[hidden]"`}},
-		}, errs[0])
 	})
 
 	t.Run("sibling property scope", func(t *testing.T) {
@@ -553,4 +565,11 @@ func assertDoesNotContainSecret(t *testing.T, value any, secret string) {
 	if strings.Contains(string(data), secret) {
 		assert.Fail(t, "JSON error contains secret %q: %s", secret, data)
 	}
+}
+
+func hiddenPropertyRules[T any](ruleDefs ...govy.RulesInterface[T]) govy.PropertyRules[T, T] {
+	return govy.For(govy.GetSelf[T]()).
+		WithName("property").
+		HideValue().
+		Rules(ruleDefs...)
 }

--- a/pkg/govy/hide_value_test.go
+++ b/pkg/govy/hide_value_test.go
@@ -38,6 +38,15 @@ func TestRule_HideValue(t *testing.T) {
 		assert.EqualError(t, rule.Validate(longSecret), `invalid values "[hidden]" and "[hidden]"`)
 	})
 
+	t.Run("truncated long value", func(t *testing.T) {
+		longSecret := strings.Repeat("sensitive-value-", 8)
+		rule := govy.NewRule(func(v string) error {
+			return fmt.Errorf("invalid value %q", v[:100]+"...")
+		}).HideValue()
+
+		assert.EqualError(t, rule.Validate(longSecret), `invalid value "[hidden]"`)
+	})
+
 	t.Run("non-string value", func(t *testing.T) {
 		rule := govy.NewRule(func(v int) error {
 			return fmt.Errorf("invalid value %d", v)
@@ -126,6 +135,23 @@ func TestRule_HideValue(t *testing.T) {
 			Code:        "outer:inner",
 			Description: "validation description",
 		}, rule.Validate(secret))
+	})
+
+	t.Run("structured property error without property value", func(t *testing.T) {
+		rule := govy.NewRule(func(v string) error {
+			return govy.NewPropertyError(
+				jsonpath.New().Name("nested"),
+				nil,
+				govy.NewRuleError(fmt.Sprintf("invalid value %q", v)),
+			)
+		}).HideValue()
+
+		err := mustErrorType[*govy.PropertyError](t, rule.Validate(secret))
+		assert.Equal(t, &govy.PropertyError{
+			PropertyPath: jsonpath.Parse("nested"),
+			Errors:       []*govy.RuleError{{Message: `invalid value "[hidden]"`}},
+		}, err)
+		assertDoesNotContainSecret(t, err, secret)
 	})
 
 	t.Run("pointer conversion", func(t *testing.T) {

--- a/pkg/govy/hide_value_test.go
+++ b/pkg/govy/hide_value_test.go
@@ -77,7 +77,7 @@ func TestPropertyRules_HideValue_RuleErrors(t *testing.T) {
 		)
 	})
 
-	t.Run("message template metadata", func(t *testing.T) {
+	t.Run("message template redacts only property value and error", func(t *testing.T) {
 		rule := govy.NewRule(func(v string) error {
 			return govy.NewRuleErrorTemplate(govy.TemplateVars{
 				Error:  fmt.Sprintf("nested error for %q", v),
@@ -94,7 +94,7 @@ func TestPropertyRules_HideValue_RuleErrors(t *testing.T) {
 			t,
 			hiddenPropertyRules(rule).Validate(secret),
 			"property",
-			`[hidden]: nested error for "[hidden]"; details for "[hidden]"; [hidden]; custom value "[hidden]"`,
+			`[hidden]: nested error for "[hidden]"; details for "secret"; secret; custom value "secret"`,
 		)
 	})
 

--- a/pkg/govy/hide_value_test.go
+++ b/pkg/govy/hide_value_test.go
@@ -1,0 +1,530 @@
+package govy_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/nobl9/govy/internal/assert"
+
+	"github.com/nobl9/govy/pkg/govy"
+	"github.com/nobl9/govy/pkg/jsonpath"
+	"github.com/nobl9/govy/pkg/rules"
+)
+
+func TestRule_HideValue(t *testing.T) {
+	const secret = "secret"
+
+	t.Run("plain error", func(t *testing.T) {
+		rule := govy.NewRule(func(v string) error {
+			return fmt.Errorf("invalid value %q", v)
+		})
+		hiddenRule := rule.HideValue()
+
+		assert.EqualError(t, rule.Validate(secret), `invalid value "secret"`)
+		assert.EqualError(t, hiddenRule.Validate(secret), `invalid value "[hidden]"`)
+		assert.EqualError(t, rule.Validate(secret), `invalid value "secret"`)
+	})
+
+	t.Run("long repeated value", func(t *testing.T) {
+		longSecret := strings.Repeat("sensitive-value-", 8)
+		rule := govy.NewRule(func(v string) error {
+			return fmt.Errorf("invalid values %q and %q", v, v)
+		}).HideValue()
+
+		assert.EqualError(t, rule.Validate(longSecret), `invalid values "[hidden]" and "[hidden]"`)
+	})
+
+	t.Run("non-string value", func(t *testing.T) {
+		rule := govy.NewRule(func(v int) error {
+			return fmt.Errorf("invalid value %d", v)
+		}).HideValue()
+
+		assert.EqualError(t, rule.Validate(42), "invalid value [hidden]")
+	})
+
+	t.Run("message template", func(t *testing.T) {
+		rule := govy.NewRule(func(v string) error {
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				Error: fmt.Sprintf("nested error for %q", v),
+			})
+		}).
+			WithMessageTemplateString("{{ .PropertyValue }}: {{ .Error }}").
+			HideValue()
+
+		assert.EqualError(t, rule.Validate(secret), `[hidden]: nested error for "[hidden]"`)
+	})
+
+	t.Run("message template metadata", func(t *testing.T) {
+		rule := govy.NewRule(func(v string) error {
+			return govy.NewRuleErrorTemplate(govy.TemplateVars{
+				Error:  fmt.Sprintf("nested error for %q", v),
+				Custom: fmt.Sprintf("custom value %q", v),
+			})
+		}).
+			WithDetails(fmt.Sprintf("details for %q", secret)).
+			WithExamples(secret).
+			WithMessageTemplateString(
+				"{{ .PropertyValue }}: {{ .Error }}; {{ .Details }}; {{ index .Examples 0 }}; {{ .Custom }}",
+			).
+			HideValue()
+
+		assert.EqualError(
+			t,
+			rule.Validate(secret),
+			`[hidden]: nested error for "[hidden]"; details for "[hidden]"; [hidden]; custom value "[hidden]"`,
+		)
+	})
+
+	t.Run("configured message", func(t *testing.T) {
+		rule := govy.NewRule(func(string) error {
+			return errors.New("original error")
+		}).
+			WithMessage(fmt.Sprintf("invalid value %q", secret)).
+			WithDetails(fmt.Sprintf("details for %q", secret)).
+			WithExamples(secret).
+			HideValue()
+
+		assert.EqualError(
+			t,
+			rule.Validate(secret),
+			`invalid value "[hidden]" (e.g. '[hidden]'); details for "[hidden]"`,
+		)
+	})
+
+	t.Run("structured rule error", func(t *testing.T) {
+		rule := govy.NewRule(func(v string) error {
+			return govy.NewRuleError(fmt.Sprintf("invalid value %q", v), "inner")
+		}).
+			WithErrorCode("outer").
+			WithDescription("validation description").
+			HideValue()
+
+		assert.Equal(t, &govy.RuleError{
+			Message:     `invalid value "[hidden]"`,
+			Code:        "outer:inner",
+			Description: "validation description",
+		}, rule.Validate(secret))
+	})
+
+	t.Run("structured rule error with configured message", func(t *testing.T) {
+		rule := govy.NewRule(func(string) error {
+			return govy.NewRuleError("underlying error", "inner")
+		}).
+			WithMessage(fmt.Sprintf("invalid value %q", secret)).
+			WithDetails(fmt.Sprintf("details for %q", secret)).
+			WithExamples(secret).
+			WithErrorCode("outer").
+			WithDescription("validation description").
+			HideValue()
+
+		assert.Equal(t, &govy.RuleError{
+			Message:     `invalid value "[hidden]" (e.g. '[hidden]'); details for "[hidden]"`,
+			Code:        "outer:inner",
+			Description: "validation description",
+		}, rule.Validate(secret))
+	})
+
+	t.Run("pointer conversion", func(t *testing.T) {
+		rule := govy.NewRule(func(v string) error {
+			return fmt.Errorf("invalid value %q", v)
+		}).HideValue()
+
+		assert.EqualError(t, govy.RuleToPointer(rule).Validate(ptr(secret)), `invalid value "[hidden]"`)
+	})
+
+	t.Run("rule set pointer conversion", func(t *testing.T) {
+		ruleSet := govy.NewRuleSet(govy.NewRule(func(v string) error {
+			return fmt.Errorf("invalid value %q", v)
+		}).HideValue())
+
+		err := govy.RuleSetToPointer(ruleSet).Validate(ptr(secret))
+		errs := mustErrorType[govy.RuleSetError](t, err)
+		assert.Require(t, assert.Len(t, errs, 1))
+		assert.EqualError(t, errs[0], `invalid value "[hidden]"`)
+	})
+}
+
+func TestPropertyRules_HideValue(t *testing.T) {
+	const secret = "secret"
+
+	t.Run("plain error", func(t *testing.T) {
+		expectedErr := errors.New("oh no! here's the value: 'secret'")
+		propertyRules := govy.For(govy.GetSelf[string]()).
+			WithPath(jsonpath.New().Name("test").Name("path")).
+			Rules(govy.NewRule(func(string) error { return expectedErr }))
+		hiddenPropertyRules := propertyRules.HideValue()
+
+		assert.EqualError(
+			t,
+			propertyRules.Validate(secret),
+			"- 'test.path' with value 'secret':\n  - oh no! here's the value: 'secret'",
+		)
+		errs := mustPropertyErrors(t, hiddenPropertyRules.Validate(secret))
+		assert.Require(t, assert.Len(t, errs, 1))
+		assert.Equal(t, &govy.PropertyError{
+			PropertyPath:  jsonpath.Parse("test.path"),
+			PropertyValue: "",
+			Errors:        []*govy.RuleError{{Message: "oh no! here's the value: '[hidden]'"}},
+		}, errs[0])
+		assert.EqualError(
+			t,
+			propertyRules.Validate(secret),
+			"- 'test.path' with value 'secret':\n  - oh no! here's the value: 'secret'",
+		)
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		propertyRules := govy.For(govy.GetSelf[string]()).
+			WithName("password").
+			Required().
+			HideValue()
+
+		err := propertyRules.Validate("")
+		assert.EqualError(t, err, "- 'password':\n  - property is required but was empty")
+	})
+
+	t.Run("whitespace-only value", func(t *testing.T) {
+		tests := map[string]string{
+			"ASCII whitespace":   " \t\n",
+			"Unicode whitespace": "\u3000",
+		}
+		for name, value := range tests {
+			t.Run(name, func(t *testing.T) {
+				propertyRules := govy.For(govy.GetSelf[string]()).
+					WithName("password").
+					HideValue().
+					Rules(rules.StringNotEmpty())
+
+				err := propertyRules.Validate(value)
+				assert.EqualError(t, err, "- 'password':\n  - string must not be empty")
+			})
+		}
+	})
+
+	t.Run("rule-only scope", func(t *testing.T) {
+		propertyRules := govy.For(govy.GetSelf[string]()).
+			WithName("password").
+			Rules(govy.NewRule(func(v string) error {
+				return fmt.Errorf("invalid value %q", v)
+			}).HideValue())
+
+		errs := mustPropertyErrors(t, propertyRules.Validate(secret))
+		assert.Require(t, assert.Len(t, errs, 1))
+		assert.Equal(t, &govy.PropertyError{
+			PropertyPath:  jsonpath.Parse("password"),
+			PropertyValue: secret,
+			Errors:        []*govy.RuleError{{Message: `invalid value "[hidden]"`}},
+		}, errs[0])
+	})
+
+	t.Run("sibling property scope", func(t *testing.T) {
+		type credentials struct {
+			Password string
+			Username string
+		}
+		invalidValueRule := func() govy.Rule[string] {
+			return govy.NewRule(func(v string) error {
+				return fmt.Errorf("invalid value %q", v)
+			})
+		}
+		validator := govy.New(
+			govy.For(func(v credentials) string { return v.Password }).
+				WithName("password").
+				HideValue().
+				Rules(invalidValueRule()),
+			govy.For(func(v credentials) string { return v.Username }).
+				WithName("username").
+				Rules(invalidValueRule()),
+		)
+
+		err := validator.Validate(credentials{Password: secret, Username: "public"})
+		assert.Equal(t, &govy.ValidatorError{Errors: govy.PropertyErrors{
+			{
+				PropertyPath: jsonpath.Parse("password"),
+				Errors:       []*govy.RuleError{{Message: `invalid value "[hidden]"`}},
+			},
+			{
+				PropertyPath:  jsonpath.Parse("username"),
+				PropertyValue: "public",
+				Errors:        []*govy.RuleError{{Message: `invalid value "public"`}},
+			},
+		}}, err)
+	})
+
+	t.Run("structured property error", func(t *testing.T) {
+		const nestedSecret = "nested-secret"
+		rule := govy.NewRule(func(string) error {
+			return govy.NewPropertyError(
+				jsonpath.New().Name("nested"),
+				nestedSecret,
+				govy.NewRuleError(fmt.Sprintf("invalid value %q", nestedSecret), "inner"),
+			)
+		}).WithErrorCode("outer")
+		propertyRules := govy.For(govy.GetSelf[string]()).
+			WithName("password").
+			HideValue().
+			Rules(rule)
+
+		errs := mustPropertyErrors(t, propertyRules.Validate(secret))
+		assert.Require(t, assert.Len(t, errs, 1))
+		assert.Equal(t, &govy.PropertyError{
+			PropertyPath:  jsonpath.Parse("password.nested"),
+			PropertyValue: "",
+			Errors: []*govy.RuleError{{
+				Message: `invalid value "[hidden]"`,
+				Code:    "outer:inner",
+			}},
+		}, errs[0])
+		assertDoesNotContainSecret(t, errs[0], nestedSecret)
+	})
+
+	t.Run("rule set", func(t *testing.T) {
+		propertyRules := govy.For(govy.GetSelf[string]()).
+			WithName("password").
+			HideValue().
+			Rules(govy.NewRuleSet(govy.NewRule(func(v string) error {
+				return fmt.Errorf("invalid value %q", v)
+			})))
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate(secret),
+			"password",
+			`invalid value "[hidden]"`,
+		)
+		assertDoesNotContainSecret(t, propErr, secret)
+	})
+
+	t.Run("included validator", func(t *testing.T) {
+		included := govy.New(
+			govy.For(govy.GetSelf[string]()).
+				WithName("value").
+				Rules(govy.NewRule(func(v string) error {
+					return fmt.Errorf("invalid value %q", v)
+				})),
+		)
+		propertyRules := govy.For(govy.GetSelf[string]()).
+			WithName("password").
+			HideValue().
+			Include(included)
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate(secret),
+			"password.value",
+			`invalid value "[hidden]"`,
+		)
+		assertDoesNotContainSecret(t, propErr, secret)
+	})
+
+	t.Run("included whole-slice rules", func(t *testing.T) {
+		included := govy.New(
+			govy.ForSlice(govy.GetSelf[[]string]()).
+				Rules(govy.NewRule(func(v []string) error {
+					return fmt.Errorf("invalid value [%q]", v[0])
+				})),
+		)
+		propertyRules := govy.For(govy.GetSelf[[]string]()).
+			WithName("passwords").
+			HideValue().
+			Include(included)
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate([]string{secret}),
+			"passwords",
+			"invalid value [hidden]",
+		)
+		assert.False(t, propErr.IsSliceElementError)
+		assertDoesNotContainSecret(t, propErr, secret)
+	})
+
+	t.Run("included slice element rules", func(t *testing.T) {
+		included := govy.New(
+			govy.ForSlice(govy.GetSelf[[]string]()).
+				RulesForEach(govy.NewRule(func(v string) error {
+					return fmt.Errorf("invalid value %q", v)
+				})),
+		)
+		propertyRules := govy.For(govy.GetSelf[[]string]()).
+			WithName("passwords").
+			HideValue().
+			Include(included)
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate([]string{secret}),
+			"passwords[0]",
+			`invalid value "[hidden]"`,
+		)
+		assert.True(t, propErr.IsSliceElementError)
+		assertDoesNotContainSecret(t, propErr, secret)
+	})
+
+	t.Run("included whole-map rules", func(t *testing.T) {
+		included := govy.New(
+			govy.ForMap(govy.GetSelf[map[string]string]()).
+				Rules(govy.NewRule(func(v map[string]string) error {
+					return fmt.Errorf(`invalid value {"primary":%q}`, v["primary"])
+				})),
+		)
+		propertyRules := govy.For(govy.GetSelf[map[string]string]()).
+			WithName("passwords").
+			HideValue().
+			Include(included)
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate(map[string]string{"primary": secret}),
+			"passwords",
+			"invalid value [hidden]",
+		)
+		assertDoesNotContainSecret(t, propErr, secret)
+	})
+
+	t.Run("included map key rules", func(t *testing.T) {
+		const key = "primary"
+		included := govy.New(
+			govy.ForMap(govy.GetSelf[map[string]string]()).
+				RulesForKeys(govy.NewRule(func(v string) error {
+					return fmt.Errorf("invalid value %q", v)
+				})),
+		)
+		propertyRules := govy.For(govy.GetSelf[map[string]string]()).
+			WithName("passwords").
+			HideValue().
+			Include(included)
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate(map[string]string{key: "public"}),
+			"passwords.primary",
+			`invalid value "[hidden]"`,
+		)
+		assert.True(t, propErr.IsKeyError)
+	})
+
+	t.Run("included map value rules", func(t *testing.T) {
+		included := govy.New(
+			govy.ForMap(govy.GetSelf[map[string]string]()).
+				RulesForValues(govy.NewRule(func(v string) error {
+					return fmt.Errorf("invalid value %q", v)
+				})),
+		)
+		propertyRules := govy.For(govy.GetSelf[map[string]string]()).
+			WithName("passwords").
+			HideValue().
+			Include(included)
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate(map[string]string{"primary": secret}),
+			"passwords.primary",
+			`invalid value "[hidden]"`,
+		)
+		assert.False(t, propErr.IsKeyError)
+		assertDoesNotContainSecret(t, propErr, secret)
+	})
+
+	t.Run("included map item rules", func(t *testing.T) {
+		included := govy.New(
+			govy.ForMap(govy.GetSelf[map[string]string]()).
+				RulesForItems(govy.NewRule(func(item govy.MapItem[string, string]) error {
+					return fmt.Errorf("invalid value %q", item.Value)
+				})),
+		)
+		propertyRules := govy.For(govy.GetSelf[map[string]string]()).
+			WithName("passwords").
+			HideValue().
+			Include(included)
+
+		propErr := assertHiddenPropertyError(
+			t,
+			propertyRules.Validate(map[string]string{"primary": secret}),
+			"passwords.primary",
+			`invalid value "[hidden]"`,
+		)
+		assertDoesNotContainSecret(t, propErr, secret)
+	})
+}
+
+func TestTransform_HideValue(t *testing.T) {
+	t.Run("transform failure", func(t *testing.T) {
+		transformed := govy.Transform(govy.GetSelf[string](), strconv.Atoi).
+			WithName("prop").
+			HideValue().
+			Rules(rules.GT(123))
+
+		errs := mustPropertyErrors(t, transformed.Validate("secret!"))
+		assert.Len(t, errs, 1)
+		assert.EqualError(t, errs, expectedErrorOutput(t, "property_error_transform_with_hidden_value.txt"))
+		assert.True(t, govy.HasErrorCode(errs, govy.ErrorCodeTransform))
+	})
+
+	t.Run("rule failure", func(t *testing.T) {
+		transformed := govy.Transform(
+			govy.GetSelf[string](),
+			func(v string) (string, error) { return "transformed-" + v, nil },
+		).
+			WithName("prop").
+			HideValue().
+			Rules(govy.NewRule(func(v string) error {
+				return fmt.Errorf("invalid transformed value %q", v)
+			}))
+
+		propErr := assertHiddenPropertyError(
+			t,
+			transformed.Validate("secret"),
+			"prop",
+			`invalid transformed value "[hidden]"`,
+		)
+		assertDoesNotContainSecret(t, propErr, "secret")
+	})
+}
+
+func TestPlan_HiddenProperty(t *testing.T) {
+	propertyRules := govy.For(govy.GetSelf[string]()).
+		WithName("password").
+		Rules(rules.StringNotEmpty())
+	visiblePlan, err := govy.Plan(govy.New(propertyRules))
+	assert.Require(t, assert.NoError(t, err))
+	assert.Require(t, assert.Len(t, visiblePlan.Properties, 1))
+	assert.False(t, visiblePlan.Properties[0].IsHidden)
+
+	hiddenPlan, err := govy.Plan(govy.New(propertyRules.HideValue()))
+	assert.Require(t, assert.NoError(t, err))
+	assert.Require(t, assert.Len(t, hiddenPlan.Properties, 1))
+	assert.True(t, hiddenPlan.Properties[0].IsHidden)
+}
+
+func assertHiddenPropertyError(t *testing.T, err error, path, message string) *govy.PropertyError {
+	t.Helper()
+
+	errs := mustPropertyErrors(t, err)
+	assert.Require(t, assert.Len(t, errs, 1))
+	assert.Equal(t, jsonpath.Parse(path), errs[0].PropertyPath)
+	assert.Equal(t, "", errs[0].PropertyValue)
+	assert.Require(t, assert.Len(t, errs[0].Errors, 1))
+	assert.Equal(t, message, errs[0].Errors[0].Message)
+	return errs[0]
+}
+
+func assertDoesNotContainSecret(t *testing.T, value any, secret string) {
+	t.Helper()
+
+	if rendered := fmt.Sprint(value); strings.Contains(rendered, secret) {
+		assert.Fail(t, "Rendered error contains secret %q: %s", secret, rendered)
+	}
+	if errValue, ok := value.(error); ok && strings.Contains(errValue.Error(), secret) {
+		assert.Fail(t, "Rendered error contains secret %q: %s", secret, errValue.Error())
+	}
+	data, err := json.Marshal(value)
+	assert.Require(t, assert.NoError(t, err))
+	if strings.Contains(string(data), secret) {
+		assert.Fail(t, "JSON error contains secret %q: %s", secret, data)
+	}
+}

--- a/pkg/govy/hide_value_test.go
+++ b/pkg/govy/hide_value_test.go
@@ -103,8 +103,8 @@ func TestPropertyRules_HideValue_RuleErrors(t *testing.T) {
 			return errors.New("original error")
 		}).
 			WithMessage(fmt.Sprintf("invalid value %q", secret)).
-			WithDetails(fmt.Sprintf("details for %q", secret)).
-			WithExamples(secret)
+			WithExamples(secret).
+			WithDetails(fmt.Sprintf("details for %q", secret))
 
 		_ = assertHiddenPropertyError(
 			t,
@@ -139,8 +139,6 @@ func TestPropertyRules_HideValue_RuleErrors(t *testing.T) {
 			return govy.NewRuleError("underlying error", "inner")
 		}).
 			WithMessage(fmt.Sprintf("invalid value %q", secret)).
-			WithDetails(fmt.Sprintf("details for %q", secret)).
-			WithExamples(secret).
 			WithErrorCode("outer").
 			WithDescription("validation description")
 
@@ -148,10 +146,10 @@ func TestPropertyRules_HideValue_RuleErrors(t *testing.T) {
 			t,
 			hiddenPropertyRules(rule).Validate(secret),
 			"property",
-			`invalid value "[hidden]" (e.g. '[hidden]'); details for "[hidden]"`,
+			`invalid value "[hidden]"`,
 		)
 		assert.Equal(t, &govy.RuleError{
-			Message:     `invalid value "[hidden]" (e.g. '[hidden]'); details for "[hidden]"`,
+			Message:     `invalid value "[hidden]"`,
 			Code:        "outer:inner",
 			Description: "validation description",
 		}, propErr.Errors[0])

--- a/pkg/govy/plan.go
+++ b/pkg/govy/plan.go
@@ -103,6 +103,13 @@ type planOptions struct {
 	requirePredicateDescriptions bool
 }
 
+func (p planOptions) apply(opts []PlanOption) planOptions {
+	for _, opt := range opts {
+		p = opt(p)
+	}
+	return p
+}
+
 type PlanOption func(options planOptions) planOptions
 
 // PlanRequirePredicateDescription returns a [PlanOption] that will cause [Plan] to return an error
@@ -135,9 +142,7 @@ func Plan[T any](v Validator[T], opts ...PlanOption) (*ValidatorPlan, error) {
 		propertyPath:        jsonpath.NewRoot(),
 		path:                &builders,
 		missingDescriptions: ptr(make([]predicateLocation, 0)),
-	}
-	for _, opt := range opts {
-		rootBuilder.options = opt(rootBuilder.options)
+		options:             planOptions{}.apply(opts),
 	}
 	v.plan(rootBuilder)
 

--- a/pkg/govy/predicate.go
+++ b/pkg/govy/predicate.go
@@ -7,7 +7,14 @@ type whenOptions struct {
 	description string
 }
 
-// WhenOption applies selected option to [whenConfig].
+func (w whenOptions) apply(opts []WhenOption) whenOptions {
+	for _, opt := range opts {
+		w = opt(w)
+	}
+	return w
+}
+
+// WhenOption applies selected option to [whenOptions].
 type WhenOption func(options whenOptions) whenOptions
 
 // WhenDescription sets the description for the When condition.
@@ -41,9 +48,7 @@ type predicateMatcher[T any] struct {
 // when adds a [Predicate] to the [predicateMatcher] and applies all provided [WhenOption].
 func (p predicateMatcher[T]) when(predicate Predicate[T], opts ...WhenOption) predicateMatcher[T] {
 	container := predicateContainer[T]{predicate: predicate}
-	for _, opt := range opts {
-		container.whenOptions = opt(container.whenOptions)
-	}
+	container.whenOptions = container.apply(opts)
 	p.predicates = append(p.predicates, container)
 	return p
 }

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -108,12 +108,8 @@ func (r Rule[T]) Validate(v T, opts ...ValidationOption) error {
 		if err = r.messageTemplate.Execute(&buf, ev.vars); err != nil {
 			panic(fmt.Sprintf("failed to execute message template: %s", err))
 		}
-		message := buf.String()
-		if vOpts.hideValue {
-			message = hideStringValue(message, v)
-		}
 		return &RuleError{
-			Message:     message,
+			Message:     buf.String(),
 			Code:        r.errorCode,
 			Description: r.description,
 		}

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -91,6 +91,9 @@ func (r Rule[T]) Validate(v T, opts ...ValidationOption) error {
 		}
 		if vOpts.hideValue {
 			ev.vars.PropertyValue = hiddenValue
+			if ev.vars.Error != "" {
+				ev.vars.Error = hideStringValue(ev.vars.Error, v)
+			}
 		} else {
 			ev.vars.PropertyValue = v
 		}
@@ -116,7 +119,7 @@ func (r Rule[T]) Validate(v T, opts ...ValidationOption) error {
 		Description: r.description,
 	}
 	if vOpts.hideValue {
-		ruleErr.Message = hideStringValue(ruleErr.Message, internal.PropertyValueString(v))
+		ruleErr.Message = hideStringValue(ruleErr.Message, v)
 	}
 	return ruleErr
 }

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -28,14 +28,13 @@ func RuleToPointer[T any](rule Rule[T]) Rule[*T] {
 			}
 			return rule.validate(*v)
 		},
-		errorCode:         rule.errorCode,
-		details:           rule.details,
-		message:           rule.message,
-		messageTemplate:   rule.messageTemplate,
-		examples:          rule.examples,
-		description:       rule.description,
-		planModifiers:     rule.planModifiers,
-		validationOptions: rule.validationOptions,
+		errorCode:       rule.errorCode,
+		details:         rule.details,
+		message:         rule.message,
+		messageTemplate: rule.messageTemplate,
+		examples:        rule.examples,
+		description:     rule.description,
+		planModifiers:   rule.planModifiers,
 	}
 }
 
@@ -43,15 +42,14 @@ func RuleToPointer[T any](rule Rule[T]) Rule[*T] {
 // It evaluates the provided validation function and enhances it
 // with optional [ErrorCode] and arbitrary details.
 type Rule[T any] struct {
-	validate          func(v T) error
-	errorCode         ErrorCode
-	details           string
-	message           string
-	messageTemplate   *template.Template
-	examples          []string
-	description       string
-	planModifiers     []RulePlanModifier
-	validationOptions []ValidationOption
+	validate        func(v T) error
+	errorCode       ErrorCode
+	details         string
+	message         string
+	messageTemplate *template.Template
+	examples        []string
+	description     string
+	planModifiers   []RulePlanModifier
 }
 
 // Validate runs validation function on the provided value.
@@ -68,7 +66,6 @@ func (r Rule[T]) Validate(v T, opts ...ValidationOption) error {
 	if err == nil {
 		return nil
 	}
-	opts = append(r.validationOptions, opts...)
 	vOpts := newValidationOptions(opts...)
 
 	switch ev := err.(type) {
@@ -202,12 +199,6 @@ func (r Rule[T]) WithPlanModifiers(mods ...RulePlanModifier) Rule[T] {
 // It is used to enhance the [RulePlan], but otherwise does not appear in standard [RuleError.Error] output.
 func (r Rule[T]) WithDescription(description string) Rule[T] {
 	r.description = description
-	return r
-}
-
-// HideValue will hide the value in the [RuleError] returned by this [Rule].
-func (r Rule[T]) HideValue() Rule[T] {
-	r.validationOptions = append(r.validationOptions, hideValue())
 	return r
 }
 

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -28,13 +28,14 @@ func RuleToPointer[T any](rule Rule[T]) Rule[*T] {
 			}
 			return rule.validate(*v)
 		},
-		errorCode:       rule.errorCode,
-		details:         rule.details,
-		message:         rule.message,
-		messageTemplate: rule.messageTemplate,
-		examples:        rule.examples,
-		description:     rule.description,
-		planModifiers:   rule.planModifiers,
+		errorCode:         rule.errorCode,
+		details:           rule.details,
+		message:           rule.message,
+		messageTemplate:   rule.messageTemplate,
+		examples:          rule.examples,
+		description:       rule.description,
+		planModifiers:     rule.planModifiers,
+		validationOptions: rule.validationOptions,
 	}
 }
 
@@ -76,10 +77,17 @@ func (r Rule[T]) Validate(v T, opts ...ValidationOption) error {
 			ev.Message = createErrorMessage(r.message, r.details, r.examples)
 		}
 		ev.Description = r.description
-		return ev.AddCode(r.errorCode)
+		_ = ev.AddCode(r.errorCode)
+		if vOpts.hideValue {
+			ev.Message = hideStringValue(ev.Message, v)
+		}
+		return ev
 	case *PropertyError:
 		for _, e := range ev.Errors {
 			_ = e.AddCode(r.errorCode)
+		}
+		if vOpts.hideValue {
+			hidePropertyErrorValue(ev, ev.PropertyValue, v)
 		}
 		return ev
 	case RuleErrorTemplate:
@@ -103,8 +111,12 @@ func (r Rule[T]) Validate(v T, opts ...ValidationOption) error {
 		if err = r.messageTemplate.Execute(&buf, ev.vars); err != nil {
 			panic(fmt.Sprintf("failed to execute message template: %s", err))
 		}
+		message := buf.String()
+		if vOpts.hideValue {
+			message = hideStringValue(message, v)
+		}
 		return &RuleError{
-			Message:     buf.String(),
+			Message:     message,
 			Code:        r.errorCode,
 			Description: r.description,
 		}

--- a/pkg/govy/rule.go
+++ b/pkg/govy/rule.go
@@ -42,14 +42,15 @@ func RuleToPointer[T any](rule Rule[T]) Rule[*T] {
 // It evaluates the provided validation function and enhances it
 // with optional [ErrorCode] and arbitrary details.
 type Rule[T any] struct {
-	validate        func(v T) error
-	errorCode       ErrorCode
-	details         string
-	message         string
-	messageTemplate *template.Template
-	examples        []string
-	description     string
-	planModifiers   []RulePlanModifier
+	validate          func(v T) error
+	errorCode         ErrorCode
+	details           string
+	message           string
+	messageTemplate   *template.Template
+	examples          []string
+	description       string
+	planModifiers     []RulePlanModifier
+	validationOptions []ValidationOption
 }
 
 // Validate runs validation function on the provided value.
@@ -61,51 +62,63 @@ type Rule[T any] struct {
 //     using variables passed inside [RuleErrorTemplate.vars].
 //
 // By default, it will construct a new [*RuleError].
-func (r Rule[T]) Validate(v T) error {
-	if err := r.validate(v); err != nil {
-		switch ev := err.(type) {
-		case *RuleError:
-			if len(r.message) > 0 {
-				ev.Message = createErrorMessage(r.message, r.details, r.examples)
-			}
-			ev.Description = r.description
-			return ev.AddCode(r.errorCode)
-		case *PropertyError:
-			for _, e := range ev.Errors {
-				_ = e.AddCode(r.errorCode)
-			}
-			return ev
-		case RuleErrorTemplate:
-			if r.message != "" {
-				break
-			}
-			if r.messageTemplate == nil {
-				panic(fmt.Sprintf("rule returned %T error but message template is not set", ev))
-			}
-			ev.vars.PropertyValue = v
-			ev.vars.Details = r.details
-			ev.vars.Examples = r.examples
-			var buf bytes.Buffer
-			if err = r.messageTemplate.Execute(&buf, ev.vars); err != nil {
-				panic(fmt.Sprintf("failed to execute message template: %s", err))
-			}
-			return &RuleError{
-				Message:     buf.String(),
-				Code:        r.errorCode,
-				Description: r.description,
-			}
-		}
-		msg := err.Error()
+func (r Rule[T]) Validate(v T, opts ...ValidationOption) error {
+	err := r.validate(v)
+	if err == nil {
+		return nil
+	}
+	opts = append(r.validationOptions, opts...)
+	vOpts := newValidationOptions(opts...)
+
+	switch ev := err.(type) {
+	case *RuleError:
 		if len(r.message) > 0 {
-			msg = r.message
+			ev.Message = createErrorMessage(r.message, r.details, r.examples)
+		}
+		ev.Description = r.description
+		return ev.AddCode(r.errorCode)
+	case *PropertyError:
+		for _, e := range ev.Errors {
+			_ = e.AddCode(r.errorCode)
+		}
+		return ev
+	case RuleErrorTemplate:
+		if r.message != "" {
+			break
+		}
+		if r.messageTemplate == nil {
+			panic(fmt.Sprintf("rule returned %T error but message template is not set", ev))
+		}
+		if vOpts.hideValue {
+			ev.vars.PropertyValue = hiddenValue
+		} else {
+			ev.vars.PropertyValue = v
+		}
+		ev.vars.Details = r.details
+		ev.vars.Examples = r.examples
+		var buf bytes.Buffer
+		if err = r.messageTemplate.Execute(&buf, ev.vars); err != nil {
+			panic(fmt.Sprintf("failed to execute message template: %s", err))
 		}
 		return &RuleError{
-			Message:     createErrorMessage(msg, r.details, r.examples),
+			Message:     buf.String(),
 			Code:        r.errorCode,
 			Description: r.description,
 		}
 	}
-	return nil
+	msg := err.Error()
+	if len(r.message) > 0 {
+		msg = r.message
+	}
+	ruleErr := &RuleError{
+		Message:     createErrorMessage(msg, r.details, r.examples),
+		Code:        r.errorCode,
+		Description: r.description,
+	}
+	if vOpts.hideValue {
+		ruleErr.Message = hideStringValue(ruleErr.Message, internal.PropertyValueString(v))
+	}
+	return ruleErr
 }
 
 // WithErrorCode sets the error code for the returned [RuleError].
@@ -174,6 +187,12 @@ func (r Rule[T]) WithPlanModifiers(mods ...RulePlanModifier) Rule[T] {
 // It is used to enhance the [RulePlan], but otherwise does not appear in standard [RuleError.Error] output.
 func (r Rule[T]) WithDescription(description string) Rule[T] {
 	r.description = description
+	return r
+}
+
+// HideValue will hide the value in the [RuleError] returned by this [Rule].
+func (r Rule[T]) HideValue() Rule[T] {
+	r.validationOptions = append(r.validationOptions, hideValue())
 	return r
 }
 

--- a/pkg/govy/rule_set.go
+++ b/pkg/govy/rule_set.go
@@ -32,7 +32,7 @@ type RuleSet[T any] struct {
 func (r RuleSet[T]) Validate(v T, opts ...ValidationOption) error {
 	var errs RuleSetError
 	for i := range r.rules {
-		err := r.rules[i].Validate(v)
+		err := r.rules[i].Validate(v, opts...)
 		if err == nil {
 			continue
 		}

--- a/pkg/govy/rule_set.go
+++ b/pkg/govy/rule_set.go
@@ -29,7 +29,7 @@ type RuleSet[T any] struct {
 // except each aggregated rule is validated individually.
 // The errors are aggregated and returned as a single [RuleSetError]
 // which serves as a container for them.
-func (r RuleSet[T]) Validate(v T) error {
+func (r RuleSet[T]) Validate(v T, opts ...ValidationOption) error {
 	var errs RuleSetError
 	for i := range r.rules {
 		err := r.rules[i].Validate(v)

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -236,8 +236,11 @@ func (r PropertyRules[T, P]) OmitEmpty() PropertyRules[T, P] {
 	return r
 }
 
-// HideValue omits values from errors produced by this property
-// and replaces their string representations in rule error messages with `[hidden]`.
+// HideValue omits values from errors produced by this property.
+// For rule errors without a message template, it replaces the value text with `[hidden]`.
+// Before it executes a message template, it sets [TemplateVars.PropertyValue] to `[hidden]`
+// and redacts the value text in [TemplateVars.Error].
+// It returns the rendered template without additional redaction.
 // The setting propagates to nested rules and included validators.
 func (r PropertyRules[T, P]) HideValue() PropertyRules[T, P] {
 	r.validationOptions = append(r.validationOptions, hideValue())

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -236,8 +236,9 @@ func (r PropertyRules[T, P]) OmitEmpty() PropertyRules[T, P] {
 	return r
 }
 
-// HideValue hides the property value in the error message.
-// It's useful when the value is sensitive and should not be exposed.
+// HideValue omits values from errors produced by this property
+// and replaces their string representations in rule error messages with `[hidden]`.
+// The setting propagates to nested rules and included validators.
 func (r PropertyRules[T, P]) HideValue() PropertyRules[T, P] {
 	r.validationOptions = append(r.validationOptions, hideValue())
 	return r

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -41,14 +41,18 @@ func Transform[T, N, P any](getter PropertyGetter[T, P], transform Transformer[T
 	typInfo := typeinfo.Get[T]()
 	return PropertyRules[N, P]{
 		pathFunc: getInferPathFunc(getCallersAndProgramCounter(4)),
-		transformGetter: func(parent P) (transformed N, original any, err error) {
+		transformGetter: func(parent P, hideValue bool) (transformed N, original any, err error) {
 			v := getter(parent)
 			if internal.IsEmpty(v) {
 				return transformed, nil, emptyErr{}
 			}
 			transformed, err = transform(v)
 			if err != nil {
-				return transformed, v, NewRuleError(err.Error(), ErrorCodeTransform)
+				message := err.Error()
+				if hideValue {
+					message = hideStringValue(message, internal.PropertyValueString(v))
+				}
+				return transformed, v, NewRuleError(message, ErrorCodeTransform)
 			}
 			return transformed, v, nil
 		},
@@ -86,8 +90,8 @@ type Transformer[T, N any] func(value T) (N, error)
 type PropertyGetter[T, P any] func(parent P) T
 
 type (
-	internalPropertyGetter[T, P any]          func(P) (v T, err error)
-	internalTransformPropertyGetter[T, P any] func(P) (transformed T, original any, err error)
+	internalPropertyGetter[T, P any]          func(parent P) (v T, err error)
+	internalTransformPropertyGetter[T, P any] func(parent P, hideValue bool) (transformed T, original any, err error)
 	emptyErr                                  struct{}
 )
 
@@ -98,26 +102,26 @@ func (emptyErr) Error() string { return "" }
 // It is the middle-level building block of the validation process,
 // aggregated by [Validator] and aggregating [Rule].
 type PropertyRules[T, P any] struct {
-	path             jsonpath.Path
-	pathFunc         inferPathFunc
-	getter           internalPropertyGetter[T, P]
-	transformGetter  internalTransformPropertyGetter[T, P]
-	rules            []validationInterface[T]
-	required         bool
-	omitEmpty        bool
-	hideValue        bool
-	isPointer        bool
-	cascadeMode      CascadeMode
-	inferPathMode    InferPathMode
-	inferPathModeSet bool
-	examples         []string
-	originalType     *typeinfo.TypeInfo
+	path              jsonpath.Path
+	pathFunc          inferPathFunc
+	getter            internalPropertyGetter[T, P]
+	transformGetter   internalTransformPropertyGetter[T, P]
+	rules             []validationInterface[T]
+	required          bool
+	omitEmpty         bool
+	isPointer         bool
+	cascadeMode       CascadeMode
+	inferPathMode     InferPathMode
+	inferPathModeSet  bool
+	examples          []string
+	originalType      *typeinfo.TypeInfo
+	validationOptions []ValidationOption
 
 	predicateMatcher[P]
 }
 
 // Validate validates the property value using provided rules.
-func (r PropertyRules[T, P]) Validate(parent P) error {
+func (r PropertyRules[T, P]) Validate(parent P, opts ...ValidationOption) error {
 	if !r.matchPredicates(parent) {
 		return nil
 	}
@@ -125,18 +129,18 @@ func (r PropertyRules[T, P]) Validate(parent P) error {
 		ruleErrors []error
 		allErrors  PropertyErrors
 	)
-	propValue, skip, propErr := r.getValue(parent)
+	opts = append(r.validationOptions, opts...)
+	vOpts := newValidationOptions(opts...)
+
+	propValue, skip, propErr := r.getValue(parent, vOpts)
 	if propErr != nil {
-		if r.hideValue {
-			propErr = propErr.HideValue()
-		}
 		return PropertyErrors{propErr}
 	}
 	if skip {
 		return nil
 	}
 	for i := range r.rules {
-		err := r.rules[i].Validate(propValue)
+		err := r.rules[i].Validate(propValue, opts...)
 		if err == nil {
 			continue
 		}
@@ -156,12 +160,13 @@ func (r PropertyRules[T, P]) Validate(parent P) error {
 		}
 	}
 	if len(ruleErrors) > 0 {
-		allErrors = append(allErrors, NewPropertyError(r.getPath(), propValue, ruleErrors...))
+		anyPropValue := any(propValue)
+		if vOpts.hideValue {
+			anyPropValue = nil
+		}
+		allErrors = append(allErrors, NewPropertyError(r.getPath(), anyPropValue, ruleErrors...))
 	}
 	if len(allErrors) > 0 {
-		if r.hideValue {
-			allErrors = allErrors.HideValue()
-		}
 		return allErrors.aggregate()
 	}
 	return nil
@@ -234,7 +239,7 @@ func (r PropertyRules[T, P]) OmitEmpty() PropertyRules[T, P] {
 // HideValue hides the property value in the error message.
 // It's useful when the value is sensitive and should not be exposed.
 func (r PropertyRules[T, P]) HideValue() PropertyRules[T, P] {
-	r.hideValue = true
+	r.validationOptions = append(r.validationOptions, hideValue())
 	return r
 }
 
@@ -282,7 +287,8 @@ func (r PropertyRules[T, P]) inferPathModeInternal(mode InferPathMode) PropertyR
 
 // plan constructs a validation plan for the property.
 func (r PropertyRules[T, P]) plan(builder planBuilder) {
-	builder.propertyPlan.IsHidden = r.hideValue
+	vOpts := newValidationOptions(r.validationOptions...)
+	builder.propertyPlan.IsHidden = vOpts.hideValue
 	if r.originalType != nil {
 		builder.propertyPlan.TypeInfo = TypeInfo(*r.originalType)
 	} else {
@@ -317,14 +323,14 @@ func (r PropertyRules[T, P]) plan(builder planBuilder) {
 
 // getValue extracts the property value from the provided property.
 // It returns the value, a flag indicating whether the validation should be skipped, and any errors encountered.
-func (r PropertyRules[T, P]) getValue(parent P) (v T, skip bool, propErr *PropertyError) {
+func (r PropertyRules[T, P]) getValue(parent P, vo validationOptions) (v T, skip bool, propErr *PropertyError) {
 	var (
 		err           error
 		originalValue any
 	)
 	// Extract value from the property through correct getter.
 	if r.transformGetter != nil {
-		v, originalValue, err = r.transformGetter(parent)
+		v, originalValue, err = r.transformGetter(parent, vo.hideValue)
 	} else {
 		v, err = r.getter(parent)
 	}
@@ -337,6 +343,9 @@ func (r PropertyRules[T, P]) getValue(parent P) (v T, skip bool, propErr *Proper
 			propValue = originalValue
 		} else {
 			propValue = v
+		}
+		if vo.hideValue {
+			propValue = nil
 		}
 		return v, false, NewPropertyError(r.getPath(), propValue, err)
 	}

--- a/pkg/govy/rules.go
+++ b/pkg/govy/rules.go
@@ -50,7 +50,7 @@ func Transform[T, N, P any](getter PropertyGetter[T, P], transform Transformer[T
 			if err != nil {
 				message := err.Error()
 				if hideValue {
-					message = hideStringValue(message, internal.PropertyValueString(v))
+					message = hideStringValue(message, v)
 				}
 				return transformed, v, NewRuleError(message, ErrorCodeTransform)
 			}

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -44,7 +44,8 @@ func (r PropertyRulesForMap[M, K, V, P]) Validate(parent P, opts ...ValidationOp
 	if !r.matchPredicates(parent) {
 		return nil
 	}
-	err := r.mapRules.Validate(parent)
+	vOpts := newValidationOptions(opts...)
+	err := r.mapRules.Validate(parent, opts...)
 	var propErrs PropertyErrors
 	if err != nil {
 		if r.cascadeMode == CascadeModeStop {
@@ -59,7 +60,7 @@ func (r PropertyRulesForMap[M, K, V, P]) Validate(parent P, opts ...ValidationOp
 	}
 	for k, v := range r.getter(parent) {
 		keyPath := r.getPathForKey(k)
-		if err = r.forKeyRules.Validate(k); err != nil {
+		if err = r.forKeyRules.Validate(k, opts...); err != nil {
 			if keyErrors, ok := err.(PropertyErrors); ok {
 				for _, e := range keyErrors {
 					e.IsKeyError = true
@@ -69,7 +70,7 @@ func (r PropertyRulesForMap[M, K, V, P]) Validate(parent P, opts ...ValidationOp
 				logWrongErrorType(PropertyErrors{}, err)
 			}
 		}
-		if err = r.forValueRules.Validate(v); err != nil {
+		if err = r.forValueRules.Validate(v, opts...); err != nil {
 			if valueErrors, ok := err.(PropertyErrors); ok {
 				for _, e := range valueErrors {
 					propErrs = append(propErrs, e.prependParentPropertyPath(keyPath))
@@ -78,12 +79,10 @@ func (r PropertyRulesForMap[M, K, V, P]) Validate(parent P, opts ...ValidationOp
 				logWrongErrorType(PropertyErrors{}, err)
 			}
 		}
-		if err = r.forItemRules.Validate(MapItem[K, V]{Key: k, Value: v}); err != nil {
+		if err = r.forItemRules.Validate(MapItem[K, V]{Key: k, Value: v}, opts...); err != nil {
 			if itemErrors, ok := err.(PropertyErrors); ok {
 				for _, e := range itemErrors {
-					// TODO: Figure out how to handle custom PropertyErrors.
-					// Custom errors' value for nested item will be overridden by the actual value.
-					e.PropertyValue = internal.PropertyValueString(v)
+					setMapItemErrorValue(e, v, vOpts.hideValue)
 					propErrs = append(propErrs, e.prependParentPropertyPath(keyPath))
 				}
 			} else {
@@ -95,6 +94,16 @@ func (r PropertyRulesForMap[M, K, V, P]) Validate(parent P, opts ...ValidationOp
 		return propErrs.aggregate().sort()
 	}
 	return nil
+}
+
+func setMapItemErrorValue[V any](err *PropertyError, value V, hideValue bool) {
+	if hideValue {
+		hidePropertyErrorValue(err, value)
+		return
+	}
+	// TODO: Figure out how to handle custom PropertyErrors.
+	// Custom errors' value for nested item will be overridden by the actual value.
+	err.PropertyValue = internal.PropertyValueString(value)
 }
 
 // WithName => refer to [PropertyRules.WithName] documentation.

--- a/pkg/govy/rules_for_map.go
+++ b/pkg/govy/rules_for_map.go
@@ -40,7 +40,7 @@ type MapItem[K comparable, V any] struct {
 }
 
 // Validate executes each of the rules sequentially and aggregates the encountered errors.
-func (r PropertyRulesForMap[M, K, V, P]) Validate(parent P) error {
+func (r PropertyRulesForMap[M, K, V, P]) Validate(parent P, opts ...ValidationOption) error {
 	if !r.matchPredicates(parent) {
 		return nil
 	}

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -32,7 +32,7 @@ func (r PropertyRulesForSlice[S, T, P]) Validate(parent P, opts ...ValidationOpt
 		return nil
 	}
 	v := r.getter(parent)
-	err := r.sliceRules.Validate(v)
+	err := r.sliceRules.Validate(v, opts...)
 	var propErrs PropertyErrors
 	if err != nil {
 		if r.cascadeMode == CascadeModeStop {
@@ -46,7 +46,7 @@ func (r PropertyRulesForSlice[S, T, P]) Validate(parent P, opts ...ValidationOpt
 		}
 	}
 	for i, element := range v {
-		err = r.forEachRules.Validate(element)
+		err = r.forEachRules.Validate(element, opts...)
 		if err == nil {
 			continue
 		}

--- a/pkg/govy/rules_for_slice.go
+++ b/pkg/govy/rules_for_slice.go
@@ -27,7 +27,7 @@ type PropertyRulesForSlice[S ~[]T, T, P any] struct {
 }
 
 // Validate executes each of the rules sequentially and aggregates the encountered errors.
-func (r PropertyRulesForSlice[S, T, P]) Validate(parent P) error {
+func (r PropertyRulesForSlice[S, T, P]) Validate(parent P, opts ...ValidationOption) error {
 	if !r.matchPredicates(parent) {
 		return nil
 	}

--- a/pkg/govy/rules_test.go
+++ b/pkg/govy/rules_test.go
@@ -179,49 +179,6 @@ func TestPropertyRules(t *testing.T) {
 		assert.Require(t, assert.Len(t, errs, 1))
 		assert.Equal(t, jsonpath.Parse("simpleName"), errs[0].PropertyPath)
 	})
-
-	t.Run("hide value", func(t *testing.T) {
-		expectedErr := errors.New("oh no! here's the value: 'secret'")
-		r := govy.For(func(m mockStruct) string { return "secret" }).
-			WithPath(jsonpath.New().Name("test").Name("path")).
-			HideValue().
-			Rules(govy.NewRule(func(v string) error { return expectedErr }))
-		errs := mustPropertyErrors(t, r.Validate(mockStruct{}))
-		assert.Require(t, assert.Len(t, errs, 1))
-		assert.Equal(t, &govy.PropertyError{
-			PropertyPath:  jsonpath.Parse("test.path"),
-			PropertyValue: "",
-			Errors:        []*govy.RuleError{{Message: "oh no! here's the value: '[hidden]'"}},
-		}, errs[0])
-	})
-
-	t.Run("do not hide empty value", func(t *testing.T) {
-		r := govy.For(func(mockStruct) string { return "" }).
-			WithName("password").
-			Required().
-			HideValue()
-
-		err := r.Validate(mockStruct{})
-		assert.EqualError(t, err, "- 'password':\n  - property is required but was empty")
-	})
-
-	t.Run("do not hide whitespace-only value", func(t *testing.T) {
-		testCases := map[string]string{
-			"ASCII whitespace":   " \t\n",
-			"Unicode whitespace": "\u3000",
-		}
-		for name, value := range testCases {
-			t.Run(name, func(t *testing.T) {
-				r := govy.For(func(mockStruct) string { return value }).
-					WithName("password").
-					HideValue().
-					Rules(rules.StringNotEmpty())
-
-				err := r.Validate(mockStruct{})
-				assert.EqualError(t, err, "- 'password':\n  - string must not be empty")
-			})
-		}
-	})
 }
 
 func TestForPointer(t *testing.T) {
@@ -344,17 +301,6 @@ func TestTransform(t *testing.T) {
 		errs := mustPropertyErrors(t, transformed.Validate("123z"))
 		assert.Len(t, errs, 1)
 		assert.EqualError(t, errs, expectedErrorOutput(t, "property_error_transform.txt"))
-		assert.True(t, govy.HasErrorCode(errs, govy.ErrorCodeTransform))
-	})
-	t.Run("fail transformation with hidden value", func(t *testing.T) {
-		getter := func(s string) string { return s }
-		transformed := govy.Transform(getter, strconv.Atoi).
-			WithName("prop").
-			HideValue().
-			Rules(rules.GT(123))
-		errs := mustPropertyErrors(t, transformed.Validate("secret!"))
-		assert.Len(t, errs, 1)
-		assert.EqualError(t, errs, expectedErrorOutput(t, "property_error_transform_with_hidden_value.txt"))
 		assert.True(t, govy.HasErrorCode(errs, govy.ErrorCodeTransform))
 	})
 }

--- a/pkg/govy/validation.go
+++ b/pkg/govy/validation.go
@@ -1,6 +1,10 @@
 package govy
 
-import "github.com/nobl9/govy/pkg/jsonpath"
+import (
+	"strings"
+
+	"github.com/nobl9/govy/pkg/jsonpath"
+)
 
 // ValidatorInterface defines validation entities which group properties,
 // such as [Validator].
@@ -33,5 +37,35 @@ type RulesInterface[T any] interface {
 // validationInterface is a common interface implemented by all validation entities.
 // These include [Validator], [PropertyRules] and [Rule].
 type validationInterface[T any] interface {
-	Validate(v T) error
+	Validate(v T, opts ...ValidationOption) error
+}
+
+// validationOptions defines optional configuration passed to [validationInterface.Validate] invocations.
+type validationOptions struct {
+	hideValue bool
+}
+
+func newValidationOptions(opts ...ValidationOption) validationOptions {
+	vo := validationOptions{}
+	for _, opt := range opts {
+		vo = opt(vo)
+	}
+	return vo
+}
+
+// ValidationOption applies optional configuration to [Rule.Validate].
+type ValidationOption func(options validationOptions) validationOptions
+
+func hideValue() ValidationOption {
+	return func(options validationOptions) validationOptions {
+		options.hideValue = true
+		return options
+	}
+}
+
+func hideStringValue(message, stringValue string) string {
+	if strings.TrimSpace(stringValue) == "" {
+		return message
+	}
+	return strings.ReplaceAll(message, stringValue, hiddenValue)
 }

--- a/pkg/govy/validation.go
+++ b/pkg/govy/validation.go
@@ -54,7 +54,8 @@ func newValidationOptions(opts ...ValidationOption) validationOptions {
 	return vo
 }
 
-// ValidationOption configures value handling during validation.
+// ValidationOption carries property configuration through nested validation calls.
+// Builder methods such as [PropertyRules.HideValue] create these values internally.
 type ValidationOption func(options validationOptions) validationOptions
 
 func hideValue() ValidationOption {

--- a/pkg/govy/validation.go
+++ b/pkg/govy/validation.go
@@ -3,6 +3,7 @@ package govy
 import (
 	"strings"
 
+	"github.com/nobl9/govy/internal"
 	"github.com/nobl9/govy/pkg/jsonpath"
 )
 
@@ -63,7 +64,8 @@ func hideValue() ValidationOption {
 	}
 }
 
-func hideStringValue(message, stringValue string) string {
+func hideStringValue(message string, v any) string {
+	stringValue := internal.PropertyValueString(v)
 	if strings.TrimSpace(stringValue) == "" {
 		return message
 	}

--- a/pkg/govy/validation.go
+++ b/pkg/govy/validation.go
@@ -54,7 +54,7 @@ func newValidationOptions(opts ...ValidationOption) validationOptions {
 	return vo
 }
 
-// ValidationOption applies optional configuration to [Rule.Validate].
+// ValidationOption configures value handling during validation.
 type ValidationOption func(options validationOptions) validationOptions
 
 func hideValue() ValidationOption {
@@ -65,9 +65,22 @@ func hideValue() ValidationOption {
 }
 
 func hideStringValue(message string, v any) string {
-	stringValue := internal.PropertyValueString(v)
-	if strings.TrimSpace(stringValue) == "" {
-		return message
+	fullValue := internal.PropertyValueStringForRedaction(v)
+	if strings.TrimSpace(fullValue) != "" {
+		message = strings.ReplaceAll(message, fullValue, hiddenValue)
 	}
-	return strings.ReplaceAll(message, stringValue, hiddenValue)
+	displayValue := internal.PropertyValueString(v)
+	if displayValue != fullValue && strings.TrimSpace(displayValue) != "" {
+		message = strings.ReplaceAll(message, displayValue, hiddenValue)
+	}
+	return message
+}
+
+func hidePropertyErrorValue(err *PropertyError, values ...any) {
+	err.PropertyValue = ""
+	for _, ruleErr := range err.Errors {
+		for _, v := range values {
+			ruleErr.Message = hideStringValue(ruleErr.Message, v)
+		}
+	}
 }

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -94,7 +94,7 @@ func (v Validator[T]) InferPath(mode InferPathMode) Validator[T] {
 // Validate will first evaluate predicates before validating any rules.
 // If any predicate does not pass the validation won't be executed (returns nil).
 // All errors returned by property rules will be aggregated and wrapped in [ValidatorError].
-func (v Validator[T]) Validate(value T) error {
+func (v Validator[T]) Validate(value T, opts ...ValidationOption) error {
 	if !v.matchPredicates(value) {
 		return nil
 	}

--- a/pkg/govy/validator.go
+++ b/pkg/govy/validator.go
@@ -100,7 +100,7 @@ func (v Validator[T]) Validate(value T, opts ...ValidationOption) error {
 	}
 	var allErrors PropertyErrors
 	for _, rules := range v.props {
-		err := rules.Validate(value)
+		err := rules.Validate(value, opts...)
 		if err == nil {
 			continue
 		}


### PR DESCRIPTION
## Motivation

[Issue #273](https://github.com/nobl9/govy/issues/273) exposed the limits of applying `HideValue` after validation by mutating completed errors: an empty property value could insert `[hidden]` between every character of an error message. Version 0.28.0 fixed that immediate case, while this PR implements the planned general solution by carrying the hide-value setting through validation. The same propagation model also unblocks [issue #270](https://github.com/nobl9/govy/issues/270), which tracks adding `HideValue` to map property rules.

## Summary

- Moved hidden-value handling into validation options owned by `PropertyRules.HideValue` and propagated it through rules, validators, transforms, included validators, maps, and slices.
- Redacted full and display-form values while preserving error structure, template-author control over rendered messages, and validation-plan metadata.
- Removed the error mutation APIs that supported the previous post-validation approach.

## Testing

- Added unit coverage for empty and whitespace-only values, message-template redaction boundaries, structured and nested errors, long values, property scoping, pointer conversions, transforms, included validators, maps, slices, and validation-plan metadata.

## Release Notes

`PropertyRules.HideValue` now propagates through nested validators, transforms, maps, and slices, and redacts both full and truncated value forms. For message templates, it redacts `TemplateVars.PropertyValue` and `TemplateVars.Error` before execution and leaves all other variables under template-author control.

## Breaking Changes

- Removed `PropertyErrors.HideValue`, `(*PropertyError).HideValue`, and `(*RuleError).HideValue`. Callers must configure redaction with `PropertyRules.HideValue` before validation.
- Changed public `Validate` method signatures on validators, rules, rule sets, and property-rule types to accept `...ValidationOption`. Existing direct calls remain valid, but method values and matching interfaces must use the new signature.
