### PR TITLE
fix: preserve conditions across validation plan branches

### DIFF
--- a/pkg/govy/plan.go
+++ b/pkg/govy/plan.go
@@ -277,6 +277,10 @@ func (p planBuilder) validate() error {
 }
 
 func appendPredicatesToPlanBuilder[T any](builder planBuilder, predicates []predicateContainer[T]) planBuilder {
+	// Plan branches share inherited conditions, so clone before appending branch-specific predicates.
+	if len(predicates) > 0 {
+		builder.rulePlan.Conditions = slices.Clone(builder.rulePlan.Conditions)
+	}
 	for _, predicate := range predicates {
 		if predicate.description == "" {
 			if builder.options.requirePredicateDescriptions && builder.missingDescriptions != nil {

--- a/pkg/govy/plan_test.go
+++ b/pkg/govy/plan_test.go
@@ -361,6 +361,53 @@ func TestPlan_optionalProperties(t *testing.T) {
 	assert.Equal(t, readExpectedPlan(t, "expected_optional_properties_plan.json"), actual)
 }
 
+func TestPlan_preservesConditionsAcrossSiblingProperties(t *testing.T) {
+	type ratioMetric struct {
+		Good string
+		Bad  string
+	}
+
+	// Three inherited conditions leave spare capacity in the shared slice,
+	// reproducing the overwrite when sibling conditions are appended.
+	validator := govy.New(
+		govy.For(func(metric ratioMetric) string { return metric.Good }).
+			WithName("good").
+			Rules(rules.StringNotEmpty()).
+			When(
+				func(ratioMetric) bool { return true },
+				govy.WhenDescription("good is set"),
+			),
+		govy.For(func(metric ratioMetric) string { return metric.Bad }).
+			WithName("bad").
+			Rules(rules.StringNotEmpty()).
+			When(
+				func(ratioMetric) bool { return true },
+				govy.WhenDescription("bad is set"),
+			),
+	).
+		When(func(ratioMetric) bool { return true }, govy.WhenDescription("ratio is set")).
+		When(func(ratioMetric) bool { return true }, govy.WhenDescription("metric is set")).
+		When(func(ratioMetric) bool { return true }, govy.WhenDescription("source is set"))
+
+	plan, err := govy.Plan(validator)
+	assert.Require(t, assert.NoError(t, err))
+	assert.Require(t, assert.Len(t, plan.Properties, 2))
+
+	conditionsByPath := make(map[string][]string, len(plan.Properties))
+	for _, property := range plan.Properties {
+		assert.Require(t, assert.Len(t, property.Rules, 1))
+		conditionsByPath[property.Path.String()] = property.Rules[0].Conditions
+	}
+	assert.Equal(t, map[string][]string{
+		"$.bad": {
+			"ratio is set", "metric is set", "source is set", "bad is set",
+		},
+		"$.good": {
+			"ratio is set", "metric is set", "source is set", "good is set",
+		},
+	}, conditionsByPath)
+}
+
 func requireJSON(t *testing.T, plan *govy.ValidatorPlan) string {
 	buf := bytes.Buffer{}
 	enc := json.NewEncoder(&buf)


### PR DESCRIPTION
## Motivation

Validation plan generation could replace one branch's predicate description with a sibling branch's description when both inherited the same conditions slice. This produced incorrect plan documentation, such as a `good` ratio branch that referenced `bad`.

## Summary

Cloned inherited rule conditions before appending branch-specific predicate descriptions. This kept sibling validation plan branches independent without changing runtime validation behavior.

## Testing

Added regression coverage for sibling `good` and `bad` properties with inherited conditions. The test reproduced the overwrite before the fix and verifies that each generated rule retains its own predicate description.
