### PR TITLE
feat: include validator type information in plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,12 @@ func Example_validationPlan() {
 	//         }
 	//       ]
 	//     }
-	//   ]
+	//   ],
+	//   "typeInfo": {
+	//     "name": "Teacher",
+	//     "kind": "struct",
+	//     "package": "github.com/nobl9/govy/internal/examples"
+	//   }
 	// }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -558,6 +558,11 @@ func Example_validationPlan() {
 	// Output:
 	// {
 	//   "name": "Teacher",
+	//   "typeInfo": {
+	//     "name": "Teacher",
+	//     "kind": "struct",
+	//     "package": "github.com/nobl9/govy/internal/examples"
+	//   },
 	//   "properties": [
 	//     {
 	//       "path": "$.middleName",
@@ -665,12 +670,7 @@ func Example_validationPlan() {
 	//         }
 	//       ]
 	//     }
-	//   ],
-	//   "typeInfo": {
-	//     "name": "Teacher",
-	//     "kind": "struct",
-	//     "package": "github.com/nobl9/govy/internal/examples"
-	//   }
+	//   ]
 	// }
 }
 ```

--- a/go.work.sum
+++ b/go.work.sum
@@ -60,6 +60,7 @@ golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 h1:bTLqdHv7xrGlFbvf5/T
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
 golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959/go.mod h1:LV7u5Oco+Z/g6XI7PqN+EUUUGGkEcmB1uj2ceI0fOVg=
+golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5/go.mod h1:LVehoXe41cL5SCVQilsV7Gg6BNG+Js6P9PhSbYTIUkQ=
 golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
 golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=

--- a/internal/examples/readme_validation_plan_example_test.go
+++ b/internal/examples/readme_validation_plan_example_test.go
@@ -79,6 +79,11 @@ func Example_validationPlan() {
 	// Output:
 	// {
 	//   "name": "Teacher",
+	//   "typeInfo": {
+	//     "name": "Teacher",
+	//     "kind": "struct",
+	//     "package": "github.com/nobl9/govy/internal/examples"
+	//   },
 	//   "properties": [
 	//     {
 	//       "path": "$.middleName",
@@ -186,11 +191,6 @@ func Example_validationPlan() {
 	//         }
 	//       ]
 	//     }
-	//   ],
-	//   "typeInfo": {
-	//     "name": "Teacher",
-	//     "kind": "struct",
-	//     "package": "github.com/nobl9/govy/internal/examples"
-	//   }
+	//   ]
 	// }
 }

--- a/internal/examples/readme_validation_plan_example_test.go
+++ b/internal/examples/readme_validation_plan_example_test.go
@@ -186,6 +186,11 @@ func Example_validationPlan() {
 	//         }
 	//       ]
 	//     }
-	//   ]
+	//   ],
+	//   "typeInfo": {
+	//     "name": "Teacher",
+	//     "kind": "struct",
+	//     "package": "github.com/nobl9/govy/internal/examples"
+	//   }
 	// }
 }

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -1867,6 +1867,11 @@ func ExamplePlan() {
 	// Output:
 	// {
 	//   "name": "Teacher",
+	//   "typeInfo": {
+	//     "name": "Teacher",
+	//     "kind": "struct",
+	//     "package": "github.com/nobl9/govy/pkg/govy_test"
+	//   },
 	//   "properties": [
 	//     {
 	//       "path": "$.name",
@@ -1895,12 +1900,7 @@ func ExamplePlan() {
 	//         }
 	//       ]
 	//     }
-	//   ],
-	//   "typeInfo": {
-	//     "name": "Teacher",
-	//     "kind": "struct",
-	//     "package": "github.com/nobl9/govy/pkg/govy_test"
-	//   }
+	//   ]
 	// }
 }
 

--- a/pkg/govy/example_test.go
+++ b/pkg/govy/example_test.go
@@ -1895,7 +1895,12 @@ func ExamplePlan() {
 	//         }
 	//       ]
 	//     }
-	//   ]
+	//   ],
+	//   "typeInfo": {
+	//     "name": "Teacher",
+	//     "kind": "struct",
+	//     "package": "github.com/nobl9/govy/pkg/govy_test"
+	//   }
 	// }
 }
 
@@ -2043,7 +2048,7 @@ func ExampleInferPathModeGenerate() {
 	govyconfig.SetInferredPath(govyconfig.InferredPath{
 		Path: jsonpath.New().Name("name"),
 		File: "pkg/govy/example_test.go",
-		Line: 2050,
+		Line: 2055,
 	})
 
 	v2 := govy.New(

--- a/pkg/govy/plan.go
+++ b/pkg/govy/plan.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/nobl9/govy/internal/collections"
+	"github.com/nobl9/govy/internal/typeinfo"
 	"github.com/nobl9/govy/pkg/jsonpath"
 )
 
@@ -16,6 +17,8 @@ type ValidatorPlan struct {
 	Name string `json:"name,omitempty"`
 	// Properties which this [Validator] defines.
 	Properties []*PropertyPlan `json:"properties"`
+	// TypeInfo contains the type information of the validator.
+	TypeInfo TypeInfo `json:"typeInfo"`
 }
 
 // PropertyPlan is a validation plan for a single [PropertyRules].
@@ -52,7 +55,7 @@ func (p *PropertyPlan) Compare(other *PropertyPlan) int {
 	return strings.Compare(p.TypeInfo.Kind, other.TypeInfo.Kind)
 }
 
-// TypeInfo contains the type information of a property.
+// TypeInfo contains the type information of a validator or property.
 type TypeInfo struct {
 	// Name is a Go type name.
 	// Example: "Pod", "string", "int", "bool", etc.
@@ -164,6 +167,7 @@ func Plan[T any](v Validator[T], opts ...PlanOption) (*ValidatorPlan, error) {
 	return &ValidatorPlan{
 		Name:       name,
 		Properties: properties,
+		TypeInfo:   TypeInfo(typeinfo.Get[T]()),
 	}, nil
 }
 

--- a/pkg/govy/plan.go
+++ b/pkg/govy/plan.go
@@ -15,10 +15,10 @@ import (
 type ValidatorPlan struct {
 	// Name is the value provided to [Validator.WithName].
 	Name string `json:"name,omitempty"`
-	// Properties which this [Validator] defines.
-	Properties []*PropertyPlan `json:"properties"`
 	// TypeInfo contains the type information of the validator.
 	TypeInfo TypeInfo `json:"typeInfo"`
+	// Properties which this [Validator] defines.
+	Properties []*PropertyPlan `json:"properties"`
 }
 
 // PropertyPlan is a validation plan for a single [PropertyRules].

--- a/pkg/govy/test_data/expected_conditions_without_rules_plan.json
+++ b/pkg/govy/test_data/expected_conditions_without_rules_plan.json
@@ -21,5 +21,10 @@
         }
       ]
     }
-  ]
+  ],
+  "typeInfo": {
+    "name": "Foo",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  }
 }

--- a/pkg/govy/test_data/expected_conditions_without_rules_plan.json
+++ b/pkg/govy/test_data/expected_conditions_without_rules_plan.json
@@ -1,4 +1,9 @@
 {
+  "typeInfo": {
+    "name": "Foo",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  },
   "properties": [
     {
       "path": "$.Slice",
@@ -21,10 +26,5 @@
         }
       ]
     }
-  ],
-  "typeInfo": {
-    "name": "Foo",
-    "kind": "struct",
-    "package": "github.com/nobl9/govy/pkg/govy_test"
-  }
+  ]
 }

--- a/pkg/govy/test_data/expected_custom_slice_type_plan.json
+++ b/pkg/govy/test_data/expected_custom_slice_type_plan.json
@@ -1,4 +1,9 @@
 {
+  "typeInfo": {
+    "name": "Foo",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  },
   "properties": [
     {
       "path": "$",
@@ -14,10 +19,5 @@
         }
       ]
     }
-  ],
-  "typeInfo": {
-    "name": "Foo",
-    "kind": "struct",
-    "package": "github.com/nobl9/govy/pkg/govy_test"
-  }
+  ]
 }

--- a/pkg/govy/test_data/expected_custom_slice_type_plan.json
+++ b/pkg/govy/test_data/expected_custom_slice_type_plan.json
@@ -14,5 +14,10 @@
         }
       ]
     }
-  ]
+  ],
+  "typeInfo": {
+    "name": "Foo",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  }
 }

--- a/pkg/govy/test_data/expected_optional_properties_plan.json
+++ b/pkg/govy/test_data/expected_optional_properties_plan.json
@@ -1,4 +1,8 @@
 {
+  "typeInfo": {
+    "name": "string",
+    "kind": "string"
+  },
   "properties": [
     {
       "path": "$.String1",
@@ -33,9 +37,5 @@
         }
       ]
     }
-  ],
-  "typeInfo": {
-    "name": "string",
-    "kind": "string"
-  }
+  ]
 }

--- a/pkg/govy/test_data/expected_optional_properties_plan.json
+++ b/pkg/govy/test_data/expected_optional_properties_plan.json
@@ -33,5 +33,9 @@
         }
       ]
     }
-  ]
+  ],
+  "typeInfo": {
+    "name": "string",
+    "kind": "string"
+  }
 }

--- a/pkg/govy/test_data/expected_pod_plan.json
+++ b/pkg/govy/test_data/expected_pod_plan.json
@@ -280,5 +280,10 @@
         }
       ]
     }
-  ]
+  ],
+  "typeInfo": {
+    "name": "Pod",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  }
 }

--- a/pkg/govy/test_data/expected_pod_plan.json
+++ b/pkg/govy/test_data/expected_pod_plan.json
@@ -1,5 +1,10 @@
 {
   "name": "Pod",
+  "typeInfo": {
+    "name": "Pod",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  },
   "properties": [
     {
       "path": "$.apiVersion",
@@ -280,10 +285,5 @@
         }
       ]
     }
-  ],
-  "typeInfo": {
-    "name": "Pod",
-    "kind": "struct",
-    "package": "github.com/nobl9/govy/pkg/govy_test"
-  }
+  ]
 }

--- a/pkg/govy/test_data/expected_remove_duplicate_rules_plan.json
+++ b/pkg/govy/test_data/expected_remove_duplicate_rules_plan.json
@@ -1,4 +1,8 @@
 {
+  "typeInfo": {
+    "name": "string",
+    "kind": "string"
+  },
   "properties": [
     {
       "path": "$.String",
@@ -17,9 +21,5 @@
         }
       ]
     }
-  ],
-  "typeInfo": {
-    "name": "string",
-    "kind": "string"
-  }
+  ]
 }

--- a/pkg/govy/test_data/expected_remove_duplicate_rules_plan.json
+++ b/pkg/govy/test_data/expected_remove_duplicate_rules_plan.json
@@ -17,5 +17,9 @@
         }
       ]
     }
-  ]
+  ],
+  "typeInfo": {
+    "name": "string",
+    "kind": "string"
+  }
 }

--- a/pkg/govy/test_data/expected_values_intersection_plan.json
+++ b/pkg/govy/test_data/expected_values_intersection_plan.json
@@ -28,5 +28,10 @@
         }
       ]
     }
-  ]
+  ],
+  "typeInfo": {
+    "name": "PodMetadata",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  }
 }

--- a/pkg/govy/test_data/expected_values_intersection_plan.json
+++ b/pkg/govy/test_data/expected_values_intersection_plan.json
@@ -1,4 +1,9 @@
 {
+  "typeInfo": {
+    "name": "PodMetadata",
+    "kind": "struct",
+    "package": "github.com/nobl9/govy/pkg/govy_test"
+  },
   "properties": [
     {
       "path": "$",
@@ -28,10 +33,5 @@
         }
       ]
     }
-  ],
-  "typeInfo": {
-    "name": "PodMetadata",
-    "kind": "struct",
-    "package": "github.com/nobl9/govy/pkg/govy_test"
-  }
+  ]
 }


### PR DESCRIPTION
## Motivation

Validator type information is currently missing from validation plans.

## Summary

Added validator type information to generated plans and their JSON output. Updated the affected fixtures and testable examples.

## Testing

Updated plan fixtures and testable examples to cover validator type information for named structs and built-in types.

## Release Notes

Validation plans now include the validator's type information.
